### PR TITLE
Add two known issues about audio and video file sizes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-Pong
+tomDunkleCom
 ==============
 
-This is Pong.
+This is the public repository for the content hosted at www.tomdunkle.com.
 
 
 
-Usage
+Known Issues
 -----
 
-Here is how you use it:
+The following are issues I've identified while migrating the project into this git repository:
 
- * Do something
- * Do something else
+ * The video file for Walking Up Hills, episode 1, which is normally found at high_points/nv/walking_up_hills_ep_01.mp4, is 1.5GB, which is too large to host on github.
+ * All of the audio files in deersim/audio are in .wav format, and consequently one of the files (startlinglyYOURFEARISREALinanothertime.wav) is over 100MB, making it too large to host on github without using large file storage (LFS).


### PR DESCRIPTION
This change populates README.md with documentation of two issues about file size I've identified while migrating tomDunkleCom into this github repository:

- The video file for Walking Up Hills, episode 1, which is normally found at `high_points/nv/walking_up_hills_ep_01.mp4`, is 1.5GB, which is too large to host on github.
- All of the audio files in `deersim/audio` are in .wav format, and consequently one of the files (`startlinglyYOURFEARISREALinanothertime.wav`) is over 100MB, making it too large to host on github without using large file storage (LFS).