### PR TITLE
Create PowerShell script to download files over 100MB from my Google Drive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,3 @@ tomDunkleCom
 ==============
 
 This is the public repository for the content hosted at www.tomdunkle.com.
-
-
-
-Known Issues
------
-
-The following are issues I've identified while migrating the project into this git repository:
-
- * All of the audio files in deersim/audio are in .wav format, and consequently one of the files (startlinglyYOURFEARISREALinanothertime.wav) is over 100MB, making it too large to host on github without using large file storage (LFS).

--- a/README.md
+++ b/README.md
@@ -10,5 +10,4 @@ Known Issues
 
 The following are issues I've identified while migrating the project into this git repository:
 
- * The video file for Walking Up Hills, episode 1, which is normally found at high_points/nv/walking_up_hills_ep_01.mp4, is 1.5GB, which is too large to host on github.
  * All of the audio files in deersim/audio are in .wav format, and consequently one of the files (startlinglyYOURFEARISREALinanothertime.wav) is over 100MB, making it too large to host on github without using large file storage (LFS).

--- a/download_large_files.ps1
+++ b/download_large_files.ps1
@@ -1,6 +1,6 @@
 # Two files in the tomDunkleCom repository are over 100MB, which means that they cannot be hosted
-#  directly in GitHub. This script downloads those files directly from my Google Drive, where they
-#  are publicly shared. This script requires gdown to run. gdown can be installed through pip:
+#  in GitHub. This script downloads those files directly from my Google Drive, where they are
+#  publicly shared. This script requires gdown to run. gdown can be installed through pip:
 #  pip install gdown
 
 gdown https://drive.google.com/uc?id=1A4yYhlgMtY5yV-Mxbdk7jIWNrv8OyZF3 -O .\deersim\audio\startlinglyYOURFEARISREALinanothertime.wav

--- a/download_large_files.ps1
+++ b/download_large_files.ps1
@@ -1,0 +1,6 @@
+# A select few certain files in the tomDunkleCom repository are over 100MB, which means that they
+#  cannot be hosted directly in git. This script downloads those files directly from my Google
+#  Drive account, where they are publicly shared. This script requires gdown to run. gdown can be
+#  installed through pip with: pip install gdown
+
+gdown https://drive.google.com/uc?id=1Hj3G0y0QNlfq-lRnH59wOJtGjl_ANwIM -O .\high_points\nv\walking_up_hills_ep_01.mp4

--- a/download_large_files.ps1
+++ b/download_large_files.ps1
@@ -1,6 +1,7 @@
-# A select few certain files in the tomDunkleCom repository are over 100MB, which means that they
-#  cannot be hosted directly in git. This script downloads those files directly from my Google
-#  Drive account, where they are publicly shared. This script requires gdown to run. gdown can be
-#  installed through pip with: pip install gdown
+# Two files in the tomDunkleCom repository are over 100MB, which means that they cannot be hosted
+#  directly in git. This script downloads those files directly from my Google Drive, where they are
+#  publicly shared. This script requires gdown to run. gdown can be installed through pip:
+#  pip install gdown
 
+gdown https://drive.google.com/uc?id=1A4yYhlgMtY5yV-Mxbdk7jIWNrv8OyZF3 -O .\deersim\audio\startlinglyYOURFEARISREALinanothertime.wav
 gdown https://drive.google.com/uc?id=1Hj3G0y0QNlfq-lRnH59wOJtGjl_ANwIM -O .\high_points\nv\walking_up_hills_ep_01.mp4

--- a/download_large_files.ps1
+++ b/download_large_files.ps1
@@ -1,6 +1,6 @@
 # Two files in the tomDunkleCom repository are over 100MB, which means that they cannot be hosted
-#  directly in git. This script downloads those files directly from my Google Drive, where they are
-#  publicly shared. This script requires gdown to run. gdown can be installed through pip:
+#  directly in GitHub. This script downloads those files directly from my Google Drive, where they
+#  are publicly shared. This script requires gdown to run. gdown can be installed through pip:
 #  pip install gdown
 
 gdown https://drive.google.com/uc?id=1A4yYhlgMtY5yV-Mxbdk7jIWNrv8OyZF3 -O .\deersim\audio\startlinglyYOURFEARISREALinanothertime.wav


### PR DESCRIPTION
This change adds `download_large_files.ps1`, a script that downloads two files over 100MB each from my Google Drive. The script uses `gdown`, a Python package designed to facilitate downloads from Google Drive. This script will be necessary to fully populate the tomDunkleCom directory when syncing the project from GitHub, because GitHub does not allow storage of files over 100MB. GitHub Large File Storage (LFS) is not a viable option for this project, because even that extension only provides support for files up to 1GB. The video file for Walking Up Hills episode 01 is ~1.62GB.