### PR TITLE
[deersim] Align comments in getInput() to reduce the number of test failures in test_line_lengths_of_JavaScript_files.ps1

### DIFF
--- a/deersim/deersim.js
+++ b/deersim/deersim.js
@@ -206,21 +206,21 @@ var getInput = function(dt) {
 
       switch (value) { // #TODO -- consider functionalizing the repetitious sfx logic below
          case 13: // Key pressed is Enter.
-            if (deersim.state === "gameOver") {     // If the game is displaying the game over screen,
-               startMainMenu(deersim);                                           // Transition to the main menu.
-               keyTimer++;                                                       // Start the key timer.
+            if (deersim.state === "gameOver") { // If the game is displaying the game over screen,
+               startMainMenu(deersim);          // Transition to the main menu.
+               keyTimer++;                      // Start the key timer.
                pauseAndReplaySoundEffect(CONST_SOUND_INDEX_MENU_SELECTION_HIGH);
             }
             else if ((deersim.state === "main")  // If the player is viewing the main menu...
                   && (keyTimer === 0)) {         // ...and the key timer has elapsed...
                if (deersim.mainMenuCursor.menuItem === 1) { // If the first option is selected...
-                  startRound();                                                     // ...then start a round of play.
-                  deersim.pauseTimer++;                                             // ...start the pause timer.
+                  startRound();                             // ...then start a round of play.
+                  deersim.pauseTimer++;                     // ...start the pause timer.
                   pauseAndReplaySoundEffect(CONST_SOUND_INDEX_MENU_SELECTION_HIGH);
                }
                else if (deersim.mainMenuCursor.menuItem === 2) { // If the second option is selected...
-                  showCreditsMenu = !showCreditsMenu; // ...then invert flag to show credits...
-                  keyTimer++;                         // ...and start the key timer.
+                  showCreditsMenu = !showCreditsMenu;            // ...then invert flag to show credits...
+                  keyTimer++;                                    // ...and start the key timer.
                   pauseAndReplaySoundEffect(CONST_SOUND_INDEX_FRENCH_CANADIAN_GRUNT_2);
                }
                else if (deersim.mainMenuCursor.menuItem === 3) { // If the third option is selected...


### PR DESCRIPTION
The `deersim` module is old and the code hasn't been touched in years. There are several conventional changes that I'd like to make to it, including getting the whole codebase to less than 100 characters per line so that it will pass `test_line_lengths_of_JavaScript_files.ps1`.

This change is just a small edit to fix whitespace alignment in some comments in `getInput()`. The change has no functional effect on I-84 Simulator for "the Internet", but reduces the number of test failures in `test_line_lengths_of_JavaScript_files.ps1` from 64 to 60.