### PR TITLE
[deersim] Add test confirming that calling startMainMenu() initially populates the gameObjects array.

### DIFF
--- a/deersim/tests/deersim.test.js
+++ b/deersim/tests/deersim.test.js
@@ -124,6 +124,16 @@ test('calling initializeGame() populates the voices array', () => {
     expectArrayIsPopulatedWithAudioReferences(testDeerSim.voices, expectedSourceFilePaths);
 }); // calling initializeGame() populates the voices array
 
+test('calling startMainMenu() increases the number of GameObjects owned by the DeerSim object', () => {
+    const testDeerSim = initializeCanvasAndGame();
+    const gameObjects = testDeerSim.gameObjects;
+    expect(gameObjects.length).toBe(0);
+
+    startMainMenu(testDeerSim);
+
+    expect(gameObjects.length).toBeGreaterThan(0);
+}); // calling startMainMenu() increases the number of GameObjects owned by the DeerSim object
+
 test('calling startMainMenu() initializes the main menu cursor', () => {
     const testDeerSim = initializeCanvasAndGame();
     expect(testDeerSim.mainMenuCursor).toBe(undefined);

--- a/deersim/tests/deersim.test.js
+++ b/deersim/tests/deersim.test.js
@@ -124,16 +124,6 @@ test('calling initializeGame() populates the voices array', () => {
     expectArrayIsPopulatedWithAudioReferences(testDeerSim.voices, expectedSourceFilePaths);
 }); // calling initializeGame() populates the voices array
 
-test('calling startMainMenu() increases the number of GameObjects owned by the DeerSim object', () => {
-    const testDeerSim = initializeCanvasAndGame();
-    const gameObjects = testDeerSim.gameObjects;
-    expect(gameObjects.length).toBe(0);
-
-    startMainMenu(testDeerSim);
-
-    expect(gameObjects.length).toBeGreaterThan(0);
-}); // calling startMainMenu() increases the number of GameObjects owned by the DeerSim object
-
 test('calling startMainMenu() initializes the main menu cursor', () => {
     const testDeerSim = initializeCanvasAndGame();
     expect(testDeerSim.mainMenuCursor).toBe(undefined);
@@ -153,6 +143,16 @@ test('calling startMainMenu() initializes the toggle box', () => {
     expect(testDeerSim.toggleBox).not.toBe(undefined);
     // TODO: Consider what else to assert on with regards to the toggle box.
 }); // calling startMainMenu() initializes the toggle box
+
+test('calling startMainMenu() initially populates the GameObjects array', () => {
+    const testDeerSim = initializeCanvasAndGame();
+    const gameObjects = testDeerSim.gameObjects;
+    expect(gameObjects.length).toBe(0);
+
+    startMainMenu(testDeerSim);
+
+    expect(gameObjects.length).toBeGreaterThan(0);
+}); // calling startMainMenu() initially populates the GameObjects array
 
 test('calling startMainMenu() sets the game state to main', () => {
     const testDeerSim = initializeCanvasAndGame();


### PR DESCRIPTION
This change adds a new automated test case confirming that the transition function `startMainMenu()` populates the DeerSim object's `.gameObjects` array.