### PR TITLE
[deersim] Remove redundant append of DeerSim canvas to HTML body.

### DIFF
--- a/deersim/deersim.js
+++ b/deersim/deersim.js
@@ -129,7 +129,6 @@ var onPageLoad = function()
    initializeCanvas(deersim);
    initializeGame(deersim);
    startMainMenu(deersim);
-   document.body.appendChild(deersim.canvas); // Append the canvas to the HTML document. // TODO: Maybe unnecessary?
    animationTimer = 0;
    keyTimer = 0;
    animate(gameLoop); // Execute first iteration of the game loop.


### PR DESCRIPTION
When loading the deersim page, we call `getI84SimContent()` which provides [HTML that includes the deersim canvas](https://github.com/tomdunkle0/tomDunkleCom/blob/f395a53ba3c591d6abbd3b182bdd82f49956e2b3/deersim/getI84SimContent.js#L713C7-L719C50). We then call `initializeCanvas()`, which sets the DeerSim object's `.canvas` property to this canvas. After calling `initializeCanvas()`, there is an unnecessary call to `document.body.appendChild()` to append the canvas to the HTML body (which the canvas already resides in).

In practice, my hand testing showed that this `appendChild()` call is just moving the deersim canvas from its initial location to lower down in the HTML body. Because this serves no purpose, this change captures the removal of the unnecessary `appendChild()` call.

snippet of HTML body without the `appendChild()` call:

![image](https://github.com/user-attachments/assets/bd47deac-186f-4862-a0c8-e43ef57ceeec)

snippet of HTML body with the `appendChild()` call:

![image](https://github.com/user-attachments/assets/a59b5fa0-9a50-4710-973a-3c27e417f926)

