### PR TITLE
Remove almost all pseudocode comments from the deersim module.

### DIFF
--- a/deersim/aestheticObjects.js
+++ b/deersim/aestheticObjects.js
@@ -16,21 +16,17 @@
  | @param string imagePrefix -- the prefix for each frame's image handle.    |
 \*---------------------------------------------------------------------------*/
 function AnimationBlock(x, y, dim, length, imagePrefix) {
-   this.x   = x;   // Assign this AnimationBlock's x position.
-   this.y   = y;   // Assign this AnimationBlock's y position.
-   this.dim = dim; // Assign this AnimationBlock's dimension.
+   this.x   = x;
+   this.y   = y;
+   this.dim = dim;
    // #TODO -- as of writing this comment, this.dim is unused for this object. Remove it.
-   
-   // Assign this AnimationBlock's length (e.g. number of frames).
+
    this.length = length;
-   
-   // Assign the prefix for this AnimationBlock's image handles.
+
    this.imagePrefix = imagePrefix;
-   
-   // Initialize a counter for game iterations with respect to the animation's start.
+
    this.frameCounter = 0;
-   
-   // Initialize a flag for this AnimationBlock having finished.
+
    this.over = CONST_FALSE;
 };
 
@@ -41,9 +37,9 @@ function AnimationBlock(x, y, dim, length, imagePrefix) {
  | active Deer is covering distance while running along the road.             |
 \*----------------------------------------------------------------------------*/
 function Background(x, imageHandle) {
-   this.x           = x;           // Assign this Background's x position.
-   this.y           = 0;           // Backgrounds must always exist at y = 0, to fill the canvas.
-   this.imageHandle = imageHandle; // Assign this Background's image handle.
+   this.x           = x;
+   this.y           = 0;
+   this.imageHandle = imageHandle;
 };
 
 /*---------------------------------------------------------------------------------------*\
@@ -53,13 +49,13 @@ function Background(x, imageHandle) {
  | @param int y -- this Bar's y position.                                                |
 \*---------------------------------------------------------------------------------------*/
 function Bar(x, y) {
-   this.x          = x;                // Assign this Bar's x position.
-   this.y          = y;                // Assign this Bar's y position.
-   this.backWidth  = CONST_BAR_WIDTH;  // Assign this Bar's back rectangle's width.
-   this.frontWidth = 0;                // Assign this Bar's front rectangle its default width.
-   this.height     = CONST_BAR_HEIGHT; // Assign this Bar's height.
-   this.function   = "default";        // Assign a default value for this Bar's function.
-   this.done       = CONST_FALSE;      // By default, Bars are not done.
+   this.x          = x;
+   this.y          = y;
+   this.backWidth  = CONST_BAR_WIDTH;
+   this.frontWidth = 0;
+   this.height     = CONST_BAR_HEIGHT;
+   this.function   = "default";
+   this.done       = CONST_FALSE;
 }; // Bar()
 
 /*----------------------------------------------------------------------------*\
@@ -72,12 +68,11 @@ function Bar(x, y) {
  | @param size           -- the size of this Character.                       |
 \*----------------------------------------------------------------------------*/
 function Character(x, y, dim, a_state, ASCIICharacter, size) {
-   this.x    = x;    // Assign this Character's x position.
-   this.y    = y;    // Assign this Character's y position.
-   this.dim  = dim;  // Assign this Character's dimension.
-   this.size = size; // Assign this Character's size.
+   this.x    = x;
+   this.y    = y;
+   this.dim  = dim;
+   this.size = size;
 
-   // Assign this Character's ASCII character.
    this.ASCIICharacter = ASCIICharacter;
 
    var minUpper = "A"; // 65
@@ -85,7 +80,6 @@ function Character(x, y, dim, a_state, ASCIICharacter, size) {
    var minLower = "a"; // 97
    var maxLower = "z"; // 122
 
-   // Assign a font and color ID based on this Character's state (i.e. function).
    switch (a_state) {
       case "default":
          this.font  = "Mono";
@@ -105,7 +99,7 @@ function Character(x, y, dim, a_state, ASCIICharacter, size) {
          break;
    }
 
-   this.image = // the object identified by a string of this Character's qualities, concatenated.
+   this.image =
       document.getElementById(this.size + this.font + this.ASCIICharacter + this.colorID);
 };
 
@@ -117,16 +111,16 @@ function Character(x, y, dim, a_state, ASCIICharacter, size) {
  | @param int y -- this DeerHead's y position.           |
 \*-------------------------------------------------------*/
 function DeerHead(x, y) {
-    this.x = x; // Assign this DeerHead's x position.
-    this.y = y; // Assign this DeerHear's y position.
+    this.x = x;
+    this.y = y;
 };
 
 /*--------------------------------------------------------------------------*\
  | Defines the DeerStill, an object which represents a Deer standing still. |
 \*--------------------------------------------------------------------------*/
 function DeerStill(x, y) {
-   this.x = x; // Assign this DeerStill's x position.
-   this.y = y; // Assign this DeerStill's y position.
+   this.x = x;
+   this.y = y;
 };
 
 /*---------------------------------------------------------------*\
@@ -135,13 +129,10 @@ function DeerStill(x, y) {
  | @param int intensity -- (0..1..2) = (yellow..orange..red)     |
 \*---------------------------------------------------------------*/
 function Exclamation(intensity) {
-   // Initialize a counter for game iterations with respect to the Exclamation's start.
    this.frameCounter = 0;
-   
-   this.intensity = intensity; // Essentially tracks how obnoxious the Exclamation is.
-   
-   // Assign this Exclamation's positional coordinates based on its intensity.
-   // These hardcoded values are based on the static canvas size used as of v0.21.
+
+   this.intensity = intensity;
+
    if (this.intensity === 0) {
       this.x = (CONST_CANVAS_WIDTH / 2) - 61;
       this.y = 286;
@@ -205,23 +196,18 @@ function ExpiringObject(x, y, imageHandle, remainingFrames) {
  | owns an array of NumberBlocks which are used as its characters.           |
 \*---------------------------------------------------------------------------*/
 function NumberBlockString() {
-   // Assign this NumberBlockString's x position.
    this.x = CONST_CANVAS_WIDTH - (23 * 11) - 480;
-   
-   // Assign this NumberBlockString's y position.
+
    this.y = CONST_CANVAS_HEIGHT - 41;
-   
-   this.propertyDamage = 0;           // Assign the default property damage value.
-   this.pdString       = "";          // Assign the default property damage string.
-   this.numberBlocks   = new Array(); // Stores this NumberBlockString's NumberBlocks.
-   
-   // Create the first NumberBlock, which is always the one displaying '$'.
+
+   this.propertyDamage = 0;
+   this.pdString       = "";
+   this.numberBlocks   = new Array();
+
    this.numberBlocks[0] = new StaticMenuObject(this.x, this.y, "NumberBlock$");
-   
-   // Convert this Profile's property damage value to a string representation.
+
    this.intToString();
-   
-   // Create NumberBlocks and use them to populate this NumberBlockString's NumberBlock array.
+
    this.storeCharacters();
 }; // NumberBlockString()
 
@@ -230,9 +216,9 @@ function NumberBlockString() {
  | game objects exist during a round of play.  |
 \*---------------------------------------------*/
 function Road(x, y) {
-   this.x = x;                // Assign this Road's x position.
-   this.y = y;                // Assign this Road's y position.
-   this.imageHandle = "Road"; // Assign this Road's image handle to the default value.
+   this.x = x;
+   this.y = y;
+   this.imageHandle = "Road";
 };
 
 /*---------------------------------------------------------------------*\
@@ -245,25 +231,22 @@ function SpeakingYorig() {
    this.x = 900;
    this.y = CONST_CANVAS_HEIGHT;
 
-   // Counters used to control SpeakingYorig's sequence of events.
    this.animationCounter  = 0;
    this.ascendBeforeFrame = 50;
    this.descendAfterFrame = 170;
 
-   // Speech balloon to be displayed in between ascending and descending.
    this.speechBalloon = new StaticMenuObject(
       this.x - 50,
       this.y - 125,
       "YorigsSpeechBalloon"
       );
 
-   // Key icon to be displayed in between ascending and descending.
    this.keyIcon = new StaticMenuObject(
       this.x - 11,
       this.y - 116,
       "KeyIconL"
       );
-   
+
 }; // SpeakingYorig()
 
 /*--------------------------------------------------------*\
@@ -271,13 +254,13 @@ function SpeakingYorig() {
  | scenarios in order to exclaim something to the player. |
 \*--------------------------------------------------------*/
 function Starburst(x, y, imageHandle, purpose) {
-   this.x             = x;           // Assign this Starburst's x position.
-   this.y             = y;           // Assign this Starburst's y position.
-   this.yOrig         = y;           // Separately track the original y position.
-   this.imageHandle   = imageHandle; // Assign this Starburst's image handle.
-   this.slideDistance = 60;          // Distance this Starburst will slide upward visually.
-   this.purpose       = purpose;     // Assign this Starburst's purpose.
-   this.done          = CONST_FALSE; // By default, Starbursts are not done.
+   this.x             = x;
+   this.y             = y;
+   this.yOrig         = y;
+   this.imageHandle   = imageHandle;
+   this.slideDistance = 60;
+   this.purpose       = purpose;
+   this.done          = CONST_FALSE;
 }; // Starburst()
 
 /*-------------------------------------------------------------------------*\
@@ -288,9 +271,9 @@ function Starburst(x, y, imageHandle, purpose) {
  | @param string imageHandle -- a handle to this StaticMenuObject's image. |
 \*-------------------------------------------------------------------------*/
 function StaticMenuObject(x, y, imageHandle) {
-   this.x           = x;           // Assign this StaticMenuObject's x position.
-   this.y           = y;           // Assign this StaticMenuObject's y position.
-   this.imageHandle = imageHandle; // Assign this StaticMenuObject's image handle.
+   this.x           = x;
+   this.y           = y;
+   this.imageHandle = imageHandle;
 };
 
 /*-----------------------------------------------------------*\
@@ -299,15 +282,14 @@ function StaticMenuObject(x, y, imageHandle) {
  | large amount of information to the player at one time.    |
 \*-----------------------------------------------------------*/
 function TextBox(x, y) {
-   this.x             = x;  // Assign this TextBox's x position.
-   this.y             = y;  // Assign this TextBox's y position.
-   this.numberOfLines = 14; // This TextBox's number of lines of text.
+   this.x             = x;
+   this.y             = y;
+   this.numberOfLines = 14;
    // planning to parameterize this when necessary.
 
-   // Determine this TextBox's height based on its number of lines of text.
    this.height = (24 * (this.numberOfLines + 2));
 
-   this.linesOfText = new Array(); // Stores this TextBox's TextStrings.
+   this.linesOfText = new Array();
 
    // Manually compile the credits as TextStrings, plus the line length.
    // #TODO -- automate reading of this from a text file.
@@ -398,14 +380,12 @@ function TextBox(x, y) {
                                          "Small");                     // size
    this.lineLength      = this.linesOfText[0].length;
 
-   // Determine this TextBox's width based on the length of its lines of text.
    this.width = (CONST_SIZE_SMALL * (this.lineLength + 2));
 
    // #DEBUG
    // For reference, under current conditions the height
    // and width evaluate to 312 and 448, respectively.
 
-   // This TextBox's DialogBox forms a space in which to display its lines of text.
    // #TODO -- automate choice of speech balloon based on width/height
    this.dialogBox = new StaticMenuObject(this.x, this.y - 90, "SpeechBalloon448x362");
 }; // TextBox()
@@ -421,22 +401,20 @@ function TextBox(x, y) {
  | @param size     -- the size of the text to be drawn.      |
 \*-----------------------------------------------------------*/
 function TextString(x, y, charSize, a_state, string, size) {
-   this.x        = x;           // Assign this TextString's x position.
-   this.y        = y;           // Assign this TextString's y position.
-   this.yOrig    = y;           // Separate variable for this TextString's original y position.
-   this.charSize = charSize;    // Assign this TextString's Character size.
-   this.done     = CONST_FALSE; // By default, TextStrings are not done.
-   this.state    = a_state;     // Assign this TextString's state.
-   this.string   = string;      // Assign this TextString's string.
-   this.size     = size;        // Assign this TextString's size.
-   
-   // Create an array to store the characters in this TextString's string.
+   this.x        = x;
+   this.y        = y;
+   this.yOrig    = y;
+   this.charSize = charSize;
+   this.done     = CONST_FALSE;
+   this.state    = a_state;
+   this.string   = string;
+   this.size     = size;
+
    this.characters = new Array();
-   
-   // By default, TextStrings can be removed by the clearTextStrings function.
+
    this.removable = CONST_TRUE;
-   
-   this.storeCharacters(); // Create Character objects for this TextString.
+
+   this.storeCharacters();
 };
 
 // ---- End of object declarations. ----
@@ -447,17 +425,12 @@ function TextString(x, y, charSize, a_state, string, size) {
  | Draws this AnimationBlock at a rate of 12 FPS. |
 \*------------------------------------------------*/
 AnimationBlock.prototype.draw = function() {
-   // Assign frame number (of animation) based on frame counter (of game).
    var frameNumber = Math.floor(this.frameCounter / 7);
-   
-   // Create a string version of the frame number.
+
    var frameNumberString = frameNumber.toString();
-   
-   // Put together this AnimationBlock's current image handle,
-   // based on its prefix and frame number.
+
    var imageHandle = this.imagePrefix.concat(frameNumberString);
-   
-   // Draw the current animation frame.
+
    deersim.canvasContext.drawImage(document.getElementById(imageHandle), this.x, this.y);
 }
 
@@ -465,8 +438,8 @@ AnimationBlock.prototype.draw = function() {
  | Updates this AnimationBlock. |
 \*------------------------------*/
 AnimationBlock.prototype.update = function() {
-   this.frameCounter++; // Increment this AnimationBlock's frame counter.
-   
+   this.frameCounter++;
+
    // If this animation is over...
    /* if (this.frameCounter >= (7 * this.length)) {
       this.over = CONST_TRUE; // ...then mark this AnimationBlock 'over'.
@@ -478,14 +451,14 @@ AnimationBlock.prototype.update = function() {
 \*------------------------*/
 Background.prototype.draw = function() {
    deersim.canvasContext.drawImage(document.getElementById(this.imageHandle),
-                           this.x, this.y); // Draw this Background's image.
+                           this.x, this.y);
 };
 
 /*--------------------------*\
  | Updates this Background. |
 \*--------------------------*/
 Background.prototype.update = function() {
-   this.x -= 3; // Continuously move this Background to the left.
+   this.x -= 3;
 };
 
 /*-----------------*\
@@ -498,26 +471,25 @@ Bar.prototype.draw = function() {
 
       deersim.canvasContext.fillStyle = "#F6FF00"; // Set the front fill color to electric yellow.
    }
-   else if (this.function === "hp") { // Draw this Bar's back rectangle & border.
+   else if (this.function === "hp") {
       deersim.canvasContext.drawImage(document.getElementById("BossHPBarBackRectangle"),
                               (this.x - 3), (this.y - 237));
 
       deersim.canvasContext.fillStyle = "#FF0000"; // Set the front fill color to light red.
    }
-   else if (this.function === "irradiated") { // Draw this Bar's back rectangle & border.
+   else if (this.function === "irradiated") {
       deersim.canvasContext.drawImage(document.getElementById("IrradiatedBarBackRectangle"),
                               (this.x - 3), (this.y - 237));
 
       deersim.canvasContext.fillStyle = "#4FFF51"; // Set the front fill color to radioactive green.
    }
-   else { // Draw this Bar's back rectangle & border.
+   else {
       deersim.canvasContext.drawImage(document.getElementById("LevelBarBackRectangle"),
                               (this.x - 3), (this.y - 237));
 
       deersim.canvasContext.fillStyle = "#0000ff"; // Set the front fill color to dark blue.
    }
 
-   // Draw this Bar's front rectangle.
    deersim.canvasContext.fillRect(this.x, this.y, this.frontWidth, this.height);
 };
 
@@ -526,7 +498,6 @@ Bar.prototype.draw = function() {
 \*-------------------*/
 Bar.prototype.update = function() {
    if (this.function === "hp") {
-      // Assign this Bar's front width based on its owner's hit points.
       this.frontWidth = ((boss.hp / boss.maxHP) * CONST_BAR_WIDTH);
    }
    // else if (this.function === "powerup") {
@@ -535,7 +506,6 @@ Bar.prototype.update = function() {
       this.frontWidth = ((Math.abs(deer.powerupCounter - CONST_POWERUP_LEN_FRAMES))
                        / (CONST_POWERUP_LEN_FRAMES / CONST_BAR_WIDTH));
 
-      // Mark this bar 'done' if it is a powerup Bar that has fully depleted.
       if (this.frontWidth <= 0)
          this.done = CONST_TRUE;
    }
@@ -550,7 +520,6 @@ Bar.prototype.update = function() {
  | @param int nextGate    -- experience gate of the upcoming level.         |
 \*--------------------------------------------------------------------------*/
 Bar.prototype.updateFrontWidth = function(xp, currentGate, nextGate) {
-   // Calculate and assign a new front width for this Bar.
    this.frontWidth = ((xp - currentGate) / (nextGate - currentGate)) * this.backWidth;
 };
 
@@ -558,9 +527,7 @@ Bar.prototype.updateFrontWidth = function(xp, currentGate, nextGate) {
  | Draws this Character onscreen. |
 \*--------------------------------*/
 Character.prototype.draw = function() {
-   // If this Character is not a space...
    if (this.ASCIICharacter !== " ") {
-      // ...then draw this Character's image.
       deersim.canvasContext.drawImage(this.image, this.x, this.y);
    }
 };
@@ -570,7 +537,7 @@ Character.prototype.draw = function() {
 \*----------------------*/
 DeerHead.prototype.draw = function() {
     deersim.canvasContext.drawImage(document.getElementById("DeerHead"),
-                            this.x, this.y); // Draw a deer head icon.
+                            this.x, this.y);
 }; // DeerHead.draw()
 
 /*-----------------------*\
@@ -578,7 +545,7 @@ DeerHead.prototype.draw = function() {
 \*-----------------------*/
 DeerStill.prototype.draw = function() {
    deersim.canvasContext.drawImage(document.getElementById("BagDeerStill"),
-                           this.x, this.y); // Draw the default DeerStill image.
+                           this.x, this.y);
 };
 
 /*--------------------------*\
@@ -592,9 +559,7 @@ DeerStill.prototype.update = function() {}; // Necessary for inclusion in game o
 \*---------------------------------------------------------*/
 Exclamation.prototype.draw = function() {
    // #TODO -- give the Exclamation's blink a 75% (rather than 50%) duty cycle.
-   // If the game's animation timer is in the first half of its duty cycle...
    if (animationTimer < 15) {
-      // ...then draw this Exclamation's image, which depends on its intensity.
       switch (this.intensity) {
          case 0:
             deersim.canvasContext.drawImage(document.getElementById("ExclamationGraphic"),
@@ -616,7 +581,7 @@ Exclamation.prototype.draw = function() {
  | Updates this Exclamation. |
 \*---------------------------*/
 Exclamation.prototype.update = function() {
-   this.frameCounter++; // Increment this Exclamation's frame counter.
+   this.frameCounter++;
 };
 
 /*----------------------*\
@@ -639,9 +604,6 @@ ExitSign.prototype.update = function(level) {
    var prefix = "ExitSign";
    var suffix = "";
 
-   /* Determine the suffix (exit). All handles are double-digited:
-      Exits less than ten have image handles as "01", "02", etc.
-      Exits ten and above have image handles as "10", "11", etc. */
    if (level <= 9) {
       suffix = "0";
       suffix = suffix.concat(level);
@@ -650,11 +612,8 @@ ExitSign.prototype.update = function(level) {
       suffix = suffix.concat(level);
    }
 
-   // Build the full imageHandle by concatenating the prefix and suffix.
    var handle = prefix.concat(suffix);
 
-   /* If the image handle has changed since the previous game loop
-      iteration, then re-assign this ExitSign's image handle.      */
    if (handle !== this.imageHandle) {
       this.imageHandle = handle;
    }
@@ -677,15 +636,11 @@ ExpiringCursor.prototype.draw = function() {
  | Updates this ExpiringCursor. |
 \*------------------------------*/
 ExpiringCursor.prototype.update = function() {
-   /* If this ExpiringCursor's animation counter has not yet
-      elapsed, then increment it. Otherwise, reset it to zero. */
    if (this.animationCounter < 24)
       this.animationCounter++;
    else
       this.animationCounter = 0;
 
-   /* Keep a running downward count of remaining
-      game frames before this ExpiringCursor expires. */
    if (this.remainingFrames > 0)
       this.remainingFrames--;
 }; // ExpiringCursor.update()
@@ -715,7 +670,6 @@ ExpiringObject.prototype.update = function() {
  | Draws this NumberBlockString. |
 \*-------------------------------*/
 NumberBlockString.prototype.draw = function() {
-   // Draw each one of this NumberBlockString's NumberBlocks.
    for (var numberBlock in this.numberBlocks) {
       this.numberBlocks[numberBlock].draw();
    }
@@ -726,19 +680,15 @@ NumberBlockString.prototype.draw = function() {
  | to a string, in the format expected to be displayed by a NumberBlockString. |
 \*-----------------------------------------------------------------------------*/
 NumberBlockString.prototype.intToString = function() {
-   // Create a string representation of this NumberBlockString's property damage.
    var pdSuffix = this.propertyDamage.toString();
-   
-   // Stores the number of zeroes necessary to pad this NumberBlockString's property damage
-   // in order to meet the 11 character standardization of NumberBlockStrings.
+
    var numNecessaryZeroes = 10 - pdSuffix.length;
-   
-   var pdPrefix = "$"; // Stores all characters which must precede pdSuffix.
-   
-   // Add each necessary zero to pdPrefix.
+
+   var pdPrefix = "$";
+
    for (var i = 0; i < numNecessaryZeroes; i++)
       pdPrefix += "0";
-   
+
    this.pdString = pdPrefix + pdSuffix;
 };
 
@@ -747,9 +697,7 @@ NumberBlockString.prototype.intToString = function() {
  | populate this NumberBlockString's NumberBlock array. |
 \*------------------------------------------------------*/
 NumberBlockString.prototype.storeCharacters = function() {
-   // For each position in this NumberBlockString after the initial '$'...
    for (var i = 1; i < this.pdString.length; i++) {
-      // ...create a new NumberBlock to occupy the position.
       this.numberBlocks[i] = new StaticMenuObject(this.x + (i * 22),
                                              this.y,
                                              "NumberBlock" + this.pdString[i]);
@@ -761,12 +709,10 @@ NumberBlockString.prototype.storeCharacters = function() {
  | updates this NumberBlockString's NumberBlocks accordingly.       |
 \*------------------------------------------------------------------*/
 NumberBlockString.prototype.updatePropertyDamage = function(newPDvalue) {
-   this.propertyDamage = newPDvalue; // Assign the new property damage value.
-   
-   // Convert this Profile's property damage value to a string representation.
+   this.propertyDamage = newPDvalue;
+
    this.intToString();
-   
-   // Create NumberBlocks and use them to populate this NumberBlockString's NumberBlock array.
+
    this.storeCharacters();
 };
 
@@ -775,7 +721,7 @@ NumberBlockString.prototype.updatePropertyDamage = function(newPDvalue) {
 \*------------------*/
 Road.prototype.draw = function() {
    deersim.canvasContext.drawImage(document.getElementById(this.imageHandle),
-                           this.x, this.y); // Draw this Road's image.
+                           this.x, this.y);
 };
 
 /*---------------------*\
@@ -790,14 +736,12 @@ Road.prototype.update = function() {};
  | (i.e. after it finishes ascending, and before it begins descending).    |
 \*-------------------------------------------------------------------------*/
 SpeakingYorig.prototype.draw = function() {
-   deersim.canvasContext.drawImage( // Draw Yorig.
+   deersim.canvasContext.drawImage(
       document.getElementById("SpeakingYorig"), // imageHandle
       this.x,                                   // x
       this.y                                    // y
       );
 
-   /* If this SpeakingYorig currently exists between relative game frames
-      50-150, then also draw this SpeakingYorig's speech balloon and key icon. */
    if ((this.animationCounter >= this.ascendBeforeFrame)
     && (this.animationCounter <= this.descendAfterFrame))
    {
@@ -814,10 +758,10 @@ SpeakingYorig.prototype.draw = function() {
 \*-------------------------------------------------------------------------------*/
 SpeakingYorig.prototype.update = function() {
    if (this.animationCounter < this.ascendBeforeFrame)
-      this.y = this.y - 3; // Ascend before 50 game frames.
+      this.y = this.y - 3;
 
    if (this.animationCounter > this.descendAfterFrame)
-      this.y = this.y + 3; // Descend after 150 game frames.
+      this.y = this.y + 3;
 
    this.animationCounter++;
 }; // SpeakingYorig.update()
@@ -827,7 +771,7 @@ SpeakingYorig.prototype.update = function() {
 \*-----------------------*/
 Starburst.prototype.draw = function() {
    deersim.canvasContext.drawImage(document.getElementById(this.imageHandle),
-                           this.x, this.y); // Draw this Starburst's image.
+                           this.x, this.y);
 };
 
 /*------------------------------------------------------------*\
@@ -846,7 +790,7 @@ Starburst.prototype.update = function() {
 \*------------------------------*/
 StaticMenuObject.prototype.draw = function() {
    deersim.canvasContext.drawImage(document.getElementById(this.imageHandle),
-                           this.x, this.y); // Draw this StaticMenuObject's image.
+                           this.x, this.y);
 };
 
 /*---------------------------------*\
@@ -859,7 +803,7 @@ StaticMenuObject.prototype.update = function() {};
  | Draws this TextBox. |
 \*---------------------*/
 TextBox.prototype.draw = function() {
-   this.dialogBox.draw(); // Draw this TextBox's DialogBox.
+   this.dialogBox.draw();
 
    for (var lineOfText in this.linesOfText)
       this.linesOfText[lineOfText].draw();
@@ -874,10 +818,9 @@ TextBox.prototype.update = function() {}; // Necessary for inclusion in game obj
  | Draws this TextString onscreen by drawing |
  | each of its Characters, one by one.       |
 \*-------------------------------------------*/
-TextString.prototype.draw = function() {    
-   // For each Character in this TextString,
+TextString.prototype.draw = function() {
    for (var i = 0; i < this.characters.length; i++) {
-      this.characters[i].draw(); // Draw the Character.
+      this.characters[i].draw();
    }
 };
 
@@ -928,16 +871,11 @@ TextString.prototype.update = function() {
  | @param {string} newString -- value to write over this TextString's string |
 \*---------------------------------------------------------------------------*/
 TextString.prototype.updateWithStringOverwrite = function(newString) {
-   // If the new string is not equal to this TextString's current string,
    if (newString !== this.string) {
-      // Assign the new string to this TextString.
       this.string = newString;
-      
-      // Allocate a new array for this TextString's
-      // characters, and forget about the old array.
+
       this.characters = new Array();
-      
-      // Store this TextString's characters in its new array.
+
       this.storeCharacters();
    }
 };

--- a/deersim/audioEngine.js
+++ b/deersim/audioEngine.js
@@ -32,15 +32,13 @@ const CONST_VOICE_INDEX_WEENIEMOBILE_2 = 5;
  | @param string bgTrackName -- the new background track's HTML ID. |
 \*------------------------------------------------------------------*/
 var loadMusic = function(bgTrackName, bgTrackID) {
-   // Create variable to store the background music owned by the MusicManager.
    var bgTrack = deersim.musicManager.backgroundTrack;
 
-   if (!bgTrack.paused) { // If the current background music is not paused...
-      bgTrack.pause(); // ...pause and restart the existing background track.
+   if (!bgTrack.paused) {
+      bgTrack.pause();
       bgTrack.currentTime = 0;
    }
 
-   // Load and play the new background track.
    deersim.musicManager.backgroundTrack   = document.getElementById(bgTrackName);
    deersim.musicManager.backgroundTrackID = bgTrackID;
    deersim.musicManager.backgroundTrack.play();

--- a/deersim/bosses.js
+++ b/deersim/bosses.js
@@ -93,6 +93,8 @@ Coop.prototype.update = function() {
    }
 
    if (this.state === "preentry") {
+      // Coop enters the screen 14 seconds into the song, for humor's sake.
+      // This is the moment that the fast portion of the song begins.
       if (deersim.musicManager.backgroundTrack.currentTime > 14) {
          this.state = "entry";
       }

--- a/deersim/bosses.js
+++ b/deersim/bosses.js
@@ -13,12 +13,11 @@
  | gives out to potholes and speed bumps on I-84.            |
 \*-----------------------------------------------------------*/
 function Coop() {
-   this.lane       = 1;   // Assign the default lane to this Coop.
-   this.speed      = 3;   // Assign the default speed to this Coop.
-   this.hp         = 200; // Assign the default hit points to this Coop.
-   this.hitCounter = 0;   // Used to limit frequency with which this Coop is hit.
+   this.lane       = 1;
+   this.speed      = 3;
+   this.hp         = 200;
+   this.hitCounter = 0;
 
-   // Assign constant max HP referenced by other objects, e.g. Bar.
    const maxHP = 200;
    this.maxHP = maxHP;
    // #TODO -- I haven't tested, but it's very likely a client of
@@ -26,23 +25,20 @@ function Coop() {
    // 200, which I don't ideally want to be possible. Experiment
    // with this, and figure out whether there's a way to disallow it.
 
-   this.x = -100; // Assign this Coop an x position offscreen to the left.
+   this.x = -100;
 
-   /* Assign this Coop's y position based on its lane. |
-   |  Subtract an extra 64 pixels due to the increased |
-   |  size of the Coop (128x128 as opposed to 64x64).  */
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane) - 64;
 
-   this.yVelocity       = -7;         // Initialze a y velocity in case this Vehicle dies.
-   this.imageHandle     = "Coop";     // Image handle variable for this Coop.
-   this.state           = "preentry"; // Set this Coop to the pre-entry state.
-   this.laneCounter     = 0;          // Initialize a counter for lane changes.
-   this.collisionWidth  = 73;         // Visual width of Coop; used in collision detection.
-   this.rotationCounter = 0;          // Controls this Coop's angle when it dies.
-   this.angleOfRotation = 0;          // Tracks this Coop's angle when it dies.
+   this.yVelocity       = -7;
+   this.imageHandle     = "Coop";
+   this.state           = "preentry";
+   this.laneCounter     = 0;
+   this.collisionWidth  = 73;
+   this.rotationCounter = 0;
+   this.angleOfRotation = 0;
 
-   this.HPBar = new Bar(880, 699); // Create a hit point bar for this Coop.
-   this.HPBar.function = "hp";         // Flag the bar as an HP bar--not an XP bar.
+   this.HPBar = new Bar(880, 699);
+   this.HPBar.function = "hp";
 };
 
 // ---- End of object declarations. ----
@@ -54,124 +50,115 @@ function Coop() {
  | @param int direction -- represents up (1) or down (-1).             |
 \*---------------------------------------------------------------------*/
 Coop.prototype.changeLane = function(direction) {
-   this.lane += direction; // Set this Coop's lane accordingly.
+   this.lane += direction;
 
-   /* Assign this Coop's y position based on its lane. |
-   |  Subtract an extra 64 pixels due to the increased |
-   |  size of the Coop (128x128 as opposed to 64x64).  */
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane) - 64;
 
-   this.laneCounter++; // Start this Coop's lane counter.
+   this.laneCounter++;
 };
 
 /*------------------*\
  | Draws this Coop. |
 \*------------------*/
 Coop.prototype.draw = function() {
-   this.imageHandle = "Coop"; // Start with a base image handle.
+   this.imageHandle = "Coop";
 
-   // Use i to determine an angle of rotation based on this Coop's rotation counter.
    var i = this.rotationCounter / 3;
    i = Math.ceil(i);
-   if (i == 0) // In the case where rotationCounter = 0, i = 0 which is undesirable.
-      i = 12;  // Setting i to 12 in this case yields an equal distribution of angles.
+   if (i == 0)
+      i = 12;
    this.angleOfRotation = (i - 1) * 30;
 
-   // If this Coop is dying, concatenate its angle of rotation to its image handle...
    if (this.state === "dying") {
       this.imageHandle = this.imageHandle.concat("_C_");
       this.imageHandle = this.imageHandle.concat(this.angleOfRotation);
    }
 
-   // Display this Coop's current frame.
    deersim.canvasContext.drawImage(document.getElementById(this.imageHandle), this.x, this.y);
 
    /* canvasContext.drawImage(document.getElementById("Coop"),
                            this.x, this.y); // Draw this Coop's image. */
 
-   this.HPBar.draw(); // Draw this Coop's hit point bar.
+   this.HPBar.draw();
 };
 
 /*--------------------*\
  | Updates this Coop. |
 \*--------------------*/
 Coop.prototype.update = function() {
-   if (this.state === "dying") { // If Coop has been killed...
-      this.x -= 1;               // ...then move him offscreen.
-      this.y += this.yVelocity;  // Propel this Coop up or down, as...
-      this.yVelocity += 0.1;     // ...its y velocity continually increases.
+   if (this.state === "dying") {
+      this.x -= 1;
+      this.y += this.yVelocity;
+      this.yVelocity += 0.1;
    }
 
    if (this.state === "preentry") {
-      // Coop enters the screen 14 seconds into the song, for humor's sake.
-      // This is the moment that the fast portion of the song begins.
       if (deersim.musicManager.backgroundTrack.currentTime > 14) {
          this.state = "entry";
       }
    }
 
-   if ((this.state === "entry") // If this Coop is currently entering the screen...
-    && (this.x > 75))           // ...and is farther right than 75 pixels...
-      this.state = "slowing";   // ...then set this Coop's state to slowing.
+   if ((this.state === "entry")
+    && (this.x > 75))
+      this.state = "slowing";
 
-   if ((this.state === "slowing") // If this Coop is currently slowing...
-    && (this.speed > 0.5))        // ...and its speed is greater than 0.5px/frame...
-      this.speed -= 0.05;         // ...then perform a miniscule decrease in speed.
+   if ((this.state === "slowing")
+    && (this.speed > 0.5))
+      this.speed -= 0.05;
 
-   if ((this.state === "slowing")       // If this Coop is currently slowing...
-    && (Math.abs(this.speed) <= 0.5)) { // ...and its speed is less than +/-0.5px/frame...
-      this.speed = 0;                   // ...then set it to stop moving.
-      this.state = "fighting";          // ...and change its state to 'fighting'.
+   if ((this.state === "slowing")
+    && (Math.abs(this.speed) <= 0.5)) {
+      this.speed = 0;
+      this.state = "fighting";
    }
 
    if (this.state === "fighting") {
-      if ((this.lane < this.target.lane) // If this Coop is lower than the active deer...
-       && (this.laneCounter === 0))      // ...and its lane counter has elapsed...
-         this.changeLane(1);             // ...then move this Coop up one lane.
-      if ((this.lane > this.target.lane) // If this Coop is higher than the active deer...
-       && (this.laneCounter === 0))      // ...and its lane counter has elapsed...
-         this.changeLane(-1);            // ...then move this Coop down one lane.
+      if ((this.lane < this.target.lane)
+       && (this.laneCounter === 0))
+         this.changeLane(1);
+      if ((this.lane > this.target.lane)
+       && (this.laneCounter === 0))
+         this.changeLane(-1);
 
-      if ((this.x < deer.x)   // If this Coop is to the left of the active deer...
-       && (this.speed < 2)) { // ...and this Coop's speed is less than maximum...
-         this.speed += 0.05;  // ... then slightly increase this Coop's speed.
+      if ((this.x < deer.x)
+       && (this.speed < 2)) {
+         this.speed += 0.05;
       }
-      else if ((this.x > deer.x)    // If this Coop is to the right of the active deer...
-            && (this.speed > -2)) { // ...and this Coop's speed is greater than minimum...
-         this.speed -= 0.05;        // ... then slightly decrease this Coop's speed.
+      else if ((this.x > deer.x)
+            && (this.speed > -2)) {
+         this.speed -= 0.05;
       }
    }
 
-   for (projectile in deersim.projectiles) { // For every projectile in play...
+   for (projectile in deersim.projectiles) {
       if ((hasCollisionOccurred(deersim.projectiles[projectile], this))
-       && (this.hitCounter === 0)) { // If a collision with this Coop has occurred...
-         boss.hp -= 5;               // ...then decrement its hit points...
-         boss.hitCounter++;          // ...and restart its hit counter.
+       && (this.hitCounter === 0)) {
+         boss.hp -= 5;
+         boss.hitCounter++;
       }
    }
 
-   if ((this.laneCounter > 0)   // If this Coop's lane counter has started...
-    && (this.laneCounter < 30)) // ...and it has not yet elapsed...
-      this.laneCounter++;       // ...then increment this Coop's lane counter.
-   if (this.laneCounter >= 30)  // If this Coop's lane counter has elapsed...
-      this.laneCounter = 0;     // ...then reset this Coop's lane counter.
+   if ((this.laneCounter > 0)
+    && (this.laneCounter < 30))
+      this.laneCounter++;
+   if (this.laneCounter >= 30)
+      this.laneCounter = 0;
 
-   if ((this.hitCounter > 0)   // If this Coop's hit counter has started...
-    && (this.hitCounter < 30)) // ...and it has not yet elapsed...
-      this.hitCounter++;       // ...then increment this Coop's hit counter.
-   if (this.hitCounter >= 30)  // If this Coop's hit counter has elapsed...
-      this.hitCounter = 0;     // ...then reset this Coop's hit counter.
+   if ((this.hitCounter > 0)
+    && (this.hitCounter < 30))
+      this.hitCounter++;
+   if (this.hitCounter >= 30)
+      this.hitCounter = 0;
 
-   // Increment this Coop's rotation counter, and reset the counter if it has elapsed.
    this.rotationCounter++;
    if (this.rotationCounter > 35)
       this.rotationCounter = 0;
 
-   if (this.state === "exiting") // If this Coop is exiting the screen...
-      this.speed = -2;           // ...then set it to move left at a constant speed.
+   if (this.state === "exiting")
+      this.speed = -2;
 
-   if (this.state !== "preentry") // If this Coop has entered the screen...
-      this.x += this.speed;       // ...then move this Coop, proportional to its speed.
+   if (this.state !== "preentry")
+      this.x += this.speed;
 
-   this.HPBar.update(); // Update this Coop's hit point bar.
+   this.HPBar.update();
 };

--- a/deersim/deer.js
+++ b/deersim/deer.js
@@ -4,35 +4,30 @@
 \*------------------------------------------------------*/
 
 function Deer() {
-   this.angle    = 0;                // Assign this Deer's angle of rotation.
-   this.x        = -64;              // Assign this Deer's x position.
-   this.dim      = CONST_DIM_MEDIUM; // Assign this Deer's dimension.
-   this.lane     = 2;                // This deer starts the game in lane 2.
-   this.speed    = 3;                // The speed this Deer moves during initialization.
-   this.state    = "initializing";   // Set this Deer's state to initializing.
-   this.powerup  = "none";           // Assign this Deer no powerup by default.
-   this.clothing = "none";           // Assign this Deer no clothing by default.
+   this.angle    = 0;
+   this.x        = -64;
+   this.dim      = CONST_DIM_MEDIUM;
+   this.lane     = 2;
+   this.speed    = 3;
+   this.state    = "initializing";
+   this.powerup  = "none";
+   this.clothing = "none";
 
-   // Assign new position based on new lane.
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane);
 
-   // Initialize this Deer's y velocity, used when the Deer dies.
    this.yVelocity = -7;
-   
-   // Initialize a counter to control how long powerup states last.
-   this.powerupCounter = 0;
-   
-   this.rotationCounter = 0; // Initialize a counter to track this Deer's angle when it dies.
-   this.angleOfRotation = 0;  // Tracks this Deer's angle when it dies.
-   
-   this.imageHandle = ""; // Initialize an image handle variable for this Deer.
 
-   // Initialize counters used in management of this Deer's movement.
+   this.powerupCounter = 0;
+
+   this.rotationCounter = 0;
+   this.angleOfRotation = 0;
+
+   this.imageHandle = "";
+
    // this.barrierCheckerCtrLeft = 0;
    this.barrierCheckerCounter = 0;
    this.segmentCheckerCounter = 0;
 
-   // Initialize boolean values used in management of this Deer's movement.
    this.deerShouldStopMoving    = CONST_FALSE;
    this.shouldDecrementDeerLane = CONST_FALSE;
    this.shouldIncrementDeerLane = CONST_FALSE;
@@ -43,9 +38,7 @@ function Deer() {
 \*---------------------------*/
 Deer.prototype.draw = function() {
    this.imageHandle = "";
-   
-   // Create the handle to identify the correct image to display.
-   // Proper precedence is: state > powerup > clothing.
+
    if (this.powerup === "irradiated") {
       if (this.clothing === "bag")
          this.imageHandle = "BagIrradiatedDeer";
@@ -60,29 +53,24 @@ Deer.prototype.draw = function() {
       else
          this.imageHandle = "DeerImage";
    } // #TODO -- return an error image if none of the above conditions evaluate true.
-   
-   // Determine the Deer's current frame number based on its animation timer.
+
    var deerFrameNumber = Math.floor(((animationTimer / 5) + 1)).toString();
-   
-   // Concatenate the frame number to the image handle.
+
    this.imageHandle = this.imageHandle.concat(deerFrameNumber);
-   
-   // Use i to determine an angle of rotation based on this Deer's rotation counter.
+
    var i = this.rotationCounter / 3;
    i = Math.ceil(i);
-   if (i == 0) // In the case where rotationCounter = 0, i = 0 which is undesirable.
-      i = 12;  // Setting i to 12 in this case yields an equal distribution of angles.
+   if (i == 0)
+      i = 12;
    this.angleOfRotation = (i - 1) * 30;
-   
-   // If the Deer is dying, concatenate its angle of rotation to its image handle...
+
    if (this.state === "dying") {
       this.imageHandle = this.imageHandle.concat("_CC_");
       this.imageHandle = this.imageHandle.concat(this.angleOfRotation);
    }
-   else // ...otherwise, just concatenate 0 to indicate no rotation.
+   else
       this.imageHandle = this.imageHandle.concat("_CC_0");
-   
-   // Display this Deer's current frame.
+
    deersim.canvasContext.drawImage(document.getElementById(this.imageHandle), this.x, this.y);
 };
 
@@ -96,105 +84,87 @@ Deer.prototype.getInput = function(dt) {
    if ((this.state === "active")
     || (this.state === "lightning")
     || (this.state === "irradiated")) {
-      arrowKeyCounter = 0; // Reset the arrow key counter.
+      arrowKeyCounter = 0;
 
-      // Iterate through each key which is currently pressed.
       for (var key in keysDown) {
-         var value = Number(key); // Assign numeric wrapper of key to variable 'value'.
+         var value = Number(key);
 
          switch (value) {
-            case 65:                  // Key pressed is left arrow key.
-               if (this.speed > -4) { // If this Deer's speed is greater than the minimum,
-                  this.speed -= 0.2;  // Then slightly decrement its speed.
+            case 65:
+               if (this.speed > -4) {
+                  this.speed -= 0.2;
                }
 
-               // Reset this variable before testing the condition.
                this.deerShouldStopMoving = CONST_TRUE;
 
-               /* If this Deer is in an idle lane, then it should be able
-                  to move left--therefore, we can skip the upcoming check
-                  for a RoadSegment to this Deer's immediate left.        */
                if (deersim.roadManager.idleFlags[this.lane - 1] === CONST_TRUE) {
                   this.deerShouldStopMoving = CONST_FALSE;
                   arrowKeyCounter++;
                   break;
                }
 
-               /* If the barrier checker counter has elapsed and reset, then cycle through
-                  every active road segment and make sure that at least one segment matches
-                  the following criteria:
-                  
-                  1. The segment and this Deer occupy the same lane.
-                  2. The segment is slightly to the left of this Deer. */
                if (this.barrierCheckerCounter === 0) {
                   for (var roadSegment in deersim.roadManager.roadSegments) {
                      if (deersim.roadManager.roadSegments[roadSegment].lane === (this.lane - 1)) {
                         if ((deersim.roadManager.roadSegments[roadSegment].x <= (this.x - 4))
                         && (deersim.roadManager.roadSegments[roadSegment].x
                               >= ((this.x - 4) - (this.dim * 2)))) {
-                           /* If no segments match the above criteria, then
-                              raise a flag to have this Deer stop moving.   */
                            this.deerShouldStopMoving = CONST_FALSE;
                         }
                      }
 
-                     /* If the debugger is enabled, keep track
-                        of how many road segments are scanned. */
                      if (deersim.debuggerEnabled === CONST_TRUE)
                         deersim.liveDebugger.segmentCounter++;
                   }
 
-                  // If we decided that this Deer should stop moving, set its speed to zero.
                   if (this.deerShouldStopMoving === CONST_TRUE)
                      this.speed = 0;
 
-                  this.barrierCheckerCounter++; // Start the barrier checker counter.
+                  this.barrierCheckerCounter++;
                }
-            
-               arrowKeyCounter++; // Increment the arrow key counter.
+
+               arrowKeyCounter++;
                break;
-            case 87:               // Key pressed is up arrow key.
-               this.switchLane(1); // Move this Deer up one lane.
+            case 87:
+               this.switchLane(1);
                break;
-            case 68:                 // Key pressed is right arrow key.
-               if (this.speed < 4) { // If this Deer's speed is less than the maximum,
-                  this.speed += 0.2; // Then slightly increment its speed.
+            case 68:
+               if (this.speed < 4) {
+                  this.speed += 0.2;
                }
-            
-               arrowKeyCounter++; // Increment the arrow key counter.
-            
+
+               arrowKeyCounter++;
+
                break;
-            case 83:                // Key pressed is down arrow key.
-               this.switchLane(-1); // Move this Deer down one lane.
+            case 83:
+               this.switchLane(-1);
                break;
          }
       }
 
-      if (arrowKeyCounter === 0) { // If no arrow keys are currently pressed,
-         if (this.speed < -0.2) {  // If this Deer's speed is less than -0.2,
-            this.speed += 0.2;     // Then slightly increment its speed.
+      if (arrowKeyCounter === 0) {
+         if (this.speed < -0.2) {
+            this.speed += 0.2;
          }
-         else if(this.speed > 0.2) { // Else if this Deer's speed is greater than 0.2,
-            this.speed -= 0.2;       // Then slightly decrement its speed.
+         else if(this.speed > 0.2) {
+            this.speed -= 0.2;
          }
          else {
-            this.speed = 0; // Else set this Deer's speed to 0.
+            this.speed = 0;
          }
       }
 
-      // Adjust this Deer's x position by a factor of its speed.
       this.x += this.speed;
       // #TODO -- documentation
       // this.x += (this.speed * (dt / 16.67));
 
-      // Correct this Deer's x position in case it overshoots the level boundary.
-      if (this.x >= 1216) { // If this Deer's x position is greater than maximum,
-         this.x     = 1216; // Then reset this Deer's x position to maximum.
-         this.speed = 0;    // And reset this Deer's speed to zero.
+      if (this.x >= 1216) {
+         this.x     = 1216;
+         this.speed = 0;
       }
-      if (this.x <= 0) { // If this Deer's x position is less than minimum,
-         this.x     = 0; // Then reset this Deer's x position to minimum.
-         this.speed = 0; // And reset this Deer's speed to zero.
+      if (this.x <= 0) {
+         this.x     = 0;
+         this.speed = 0;
       }
    }
 };
@@ -205,8 +175,8 @@ Deer.prototype.getInput = function(dt) {
  | Additionally, this Deer's powerup counter is reset to zero.  |
 \*--------------------------------------------------------------*/
 Deer.prototype.pickupPowerup = function(powerup) {
-   this.powerup = powerup;  // Assign the new powerup to this Deer.
-   this.powerupCounter = 0; // Reset this Deer's powerup counter to 0.
+   this.powerup = powerup;
+   this.powerupCounter = 0;
 };
 
 /*--------------------*\
@@ -214,79 +184,66 @@ Deer.prototype.pickupPowerup = function(powerup) {
 \*--------------------*/
 // Deer.prototype.update = function() {
 Deer.prototype.update = function(dt) {
-   if (this.state === "active") { // If this Deer is currently active...
-      /* If the segment checker counter has elapsed and
-         reset, then cycle through every active road segment. */
+   if (this.state === "active") {
       if (this.segmentCheckerCounter === 0) {
          for (var roadSegment in deersim.roadManager.roadSegments) {
-            /* If this Deer is on top of a closing segment of the bottom lane, and
-               reaches the boundary, then automatically move this Deer up one lane. */
             if (deersim.roadManager.roadSegments[roadSegment].type === "closingBottomLane")
                if (deersim.roadManager.roadSegments[roadSegment].lane === (this.lane - 1))
                   if (deersim.roadManager.roadSegments[roadSegment].x <= this.x - (this.dim / 2))
                      this.switchLane(1);
 
-            /* If this Deer is on top of a closing segment of the top lane, and
-               reaches the boundary, then automatically move this Deer down one lane. */
             if (deersim.roadManager.roadSegments[roadSegment].type === "closingTopLane")
                if (deersim.roadManager.roadSegments[roadSegment].lane === (this.lane - 1))
                   if (deersim.roadManager.roadSegments[roadSegment].x <= this.x - (this.dim / 2))
                      this.switchLane(-1);
 
-            // If the debugger is enabled, keep track of how many road segments are scanned.
             if (deersim.debuggerEnabled === CONST_TRUE)
                deersim.liveDebugger.segmentCounter++;
          }
 
-         this.segmentCheckerCounter++; // Start the segment checker counter.
+         this.segmentCheckerCounter++;
       }
    }
 
-   if (this.state === "initializing") { // If this Deer is initializing...
-      if (this.x < 100) {      // ...and has not yet reached the active starting point,
-         this.x += this.speed; // Then adjust this Deer's x position by a factor of its speed.
+   if (this.state === "initializing") {
+      if (this.x < 100) {
+         this.x += this.speed;
          // #TODO -- documentation
          this.x += (this.speed * (dt / 1000));
       }
-      
-      if (this.x >= 97) {       // ...and has reached the active starting point,
-         this.state = "active"; // Then set this Deer's state to active.
-         this.speed = 0;        // Set this Deer's speed to zero for player control.
+
+      if (this.x >= 97) {
+         this.state = "active";
+         this.speed = 0;
       }
    }
-   
-   if (this.state === "dying") { // If this Deer is dying,
-      this.x -= 5;               // Significantly decrement this Deer's x position.
-      this.y += this.yVelocity;  // Increment this Deer's y position by its y velocity.
-      this.yVelocity += 0.1;     // Slightly increment this Deer's y velocity.
+
+   if (this.state === "dying") {
+      this.x -= 5;
+      this.y += this.yVelocity;
+      this.yVelocity += 0.1;
    }
-   
-   if ((this.powerup === "lightning")     // If this Deer is carrying the lightning powerup,
-    || (this.powerup === "irradiated")) { // Or if this Deer is irradiated,
-      this.powerupCounter++;            // Then increment this Deer's powerup counter.
-      
-      // If this Deer has been powered up for 10 seconds...
+
+   if ((this.powerup === "lightning")
+    || (this.powerup === "irradiated")) {
+      this.powerupCounter++;
+
       if (this.powerupCounter >= CONST_POWERUP_LEN_FRAMES) {
-         this.powerup = "none"; // ...then reset this Deer to no powerup.
+         this.powerup = "none";
       }
    }
-   
-   // Increment this Deer's rotation counter, and reset the counter if it has elapsed.
+
    this.rotationCounter++;
    if (this.rotationCounter > 35) {
       this.rotationCounter = 0;
    }
 
-   /* If the barrier checker counter has started, increment it.
-      If the barrier checker counter has elapsed, reset it to zero. */
    if ((this.barrierCheckerCounter > 0)
     && (this.barrierCheckerCounter < 11))
       this.barrierCheckerCounter++;
    if (this.barrierCheckerCounter >= 11)
       this.barrierCheckerCounter = 0;
 
-   /* If the segment checker counter has started, increment it.
-      If the segment checker counter has elapsed, reset it to zero. */
    if ((this.segmentCheckerCounter > 0)
     && (this.segmentCheckerCounter < 11))
       this.segmentCheckerCounter++;
@@ -301,69 +258,53 @@ Deer.prototype.update = function(dt) {
  |                     1 represents up, and -1 represents down. |
 \*--------------------------------------------------------------*/
 Deer.prototype.switchLane = function(direction) {
-   if (keyTimer !== 0) { // If the key timer has already started,
-      return;            // Do nothing.
+   if (keyTimer !== 0) {
+      return;
    }
 
-   // If the requested direction is up, cycle through every active road segment.
    if (direction === 1) {
       for (var roadSegment in deersim.roadManager.roadSegments) {
-         /* If there is a road segment directly above this Deer,
-            then give the okay for the Deer to move upwards.     */
          if (deersim.roadManager.roadSegments[roadSegment].lane === this.lane)
             if ((deersim.roadManager.roadSegments[roadSegment].x <= this.x)
              && (deersim.roadManager.roadSegments[roadSegment].x >= (this.x - (this.dim * 2))))
                this.shouldIncrementDeerLane = CONST_TRUE;
 
-         /* If the lane directly above this Deer is idle,
-            then give the okay for the Deer to move upwards. */
          if (deersim.roadManager.idleFlags[this.lane] === CONST_TRUE) {
             this.shouldIncrementDeerLane = CONST_TRUE;
          }
 
-         // If the debugger is enabled, keep track of how many road segments are scanned.
          if (deersim.debuggerEnabled === CONST_TRUE)
             deersim.liveDebugger.segmentCounter++;
       }
 
-      // If it's okay to move this Deer upward, then increment its lane and reset the flag.
       if (this.shouldIncrementDeerLane === CONST_TRUE) {
          this.lane++;
          this.shouldIncrementDeerLane = CONST_FALSE;
       }
    }
 
-   // If the requested direction is up, cycle through every active road segment.
    if (direction === -1) {
       for (var roadSegment in deersim.roadManager.roadSegments) {
-         /* If there is a road segment directly below this Deer,
-            then give the okay for the Deer to move downwards.   */
          if (deersim.roadManager.roadSegments[roadSegment].lane === (this.lane - 2))
             if ((deersim.roadManager.roadSegments[roadSegment].x <= this.x)
              && (deersim.roadManager.roadSegments[roadSegment].x >= (this.x - (this.dim * 2))))
                this.shouldDecrementDeerLane = CONST_TRUE;
 
-         /* If the lane directly below this Deer is idle,
-            then give the okay for the Deer to move downwards. */
          if (deersim.roadManager.idleFlags[this.lane - 2] === CONST_TRUE) {
             this.shouldDecrementDeerLane = CONST_TRUE;
          }
 
-         // If the debugger is enabled, keep track of how many road segments are scanned.
          if (deersim.debuggerEnabled === CONST_TRUE)
             deersim.liveDebugger.segmentCounter++;
       }
 
-      // If it's okay to move this Deer downward, then decrement its lane and reset the flag.
       if (this.shouldDecrementDeerLane === CONST_TRUE) {
          this.lane--;
          this.shouldDecrementDeerLane = CONST_FALSE;
       }
    }
 
-   // Assign new position based on new lane.
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane);
-   
-   // Start the key timer.
+
    keyTimer++;
 };

--- a/deersim/deersim.js
+++ b/deersim/deersim.js
@@ -39,20 +39,14 @@ var transitionCounter;   // Stores a counter used to manage timing of state tran
  | @param int y -- this Cursor's y position.      |
 \*------------------------------------------------*/
 function Cursor(x, y) {
-   this.x = x;                     // Assign this Cursor's x position.
-   this.y = y;                     // Assign this Cursor's y position.
-   this.d = CONST_FONT_SIZE_LARGE; // Assign this Cursor's dimension.
+   this.x = x;
+   this.y = y;
+   this.d = CONST_FONT_SIZE_LARGE;
 
-   // Assign this Cursor's menu item to a default value of 1.
-   // This 1-indexed value tracks which item in the menu this Cursor points to.
    this.menuItem = 1;
 
-   // Initialize this Cursor's animation counter,
-   // used to control timing of the Cursor's blinking.
    this.animationCounter = 0;
 
-   // Initialize this Cursor's key counter,
-   // used to control timing of the Cursor's vertical movement.
    this.keyCounter = 0;
 };
 
@@ -77,13 +71,11 @@ function DeerSim() {
 function RoadSegment(x, y, type, lane) {
    this.x      = x;
    this.y      = y;
-   this.width  = 128;  // Constant.
-   this.height = 40;   // Constant.
+   this.width  = 128;
+   this.height = 40;
    this.type   = type;
    this.lane   = lane;
 
-   /* After assigning this RoadSegment's type, also assign it an image handle
-      based on its type. The image handle is used when drawing this RoadSegment. */
    switch (this.type) {
       case "bottom":            this.imageHandle = "RoadSideBottomSegment";        break;
       case "closingBottomLane": this.imageHandle = "RoadSegmentClosingBottomLane"; break;
@@ -106,12 +98,12 @@ function RoadSegment(x, y, type, lane) {
  | @param int y2 -- this ToggleBox's second y coordinate.      |
 \*-------------------------------------------------------------*/
 function ToggleBox(x1, x2, y1, y2) {
-   this.x1 = x1; // Assign this ToggleBox's first x coordinate.
-   this.x2 = x2; // Assign this ToggleBox's second x coordinate.
-   this.y1 = y1; // Assign this ToggleBox's first y coordinate.
-   this.y2 = y2; // Assign this ToggleBox's second y coordinate.
+   this.x1 = x1;
+   this.x2 = x2;
+   this.y1 = y1;
+   this.y2 = y2;
 
-   this.coordinateSet = 0; // Assign this ToggleBox the default coordinate set.
+   this.coordinateSet = 0;
 };
 
 // ---- End of object declarations. ----
@@ -131,7 +123,7 @@ var onPageLoad = function()
    startMainMenu(deersim);
    animationTimer = 0;
    keyTimer = 0;
-   animate(gameLoop); // Execute first iteration of the game loop.
+   animate(gameLoop);
 } // onPageLoad()
 
 /*-------------------------------------------------*\
@@ -139,10 +131,9 @@ var onPageLoad = function()
  | Cursors blink based on their animation counter. |
 \*-------------------------------------------------*/
 Cursor.prototype.draw = function() {
-    // If this Cursor's animation counter is in the first half of its phase,
     if (this.animationCounter < 12) {
         deersim.canvasContext.drawImage(document.getElementById("DeerHead"),
-                                this.x, this.y); // Then draw a deer head icon.
+                                this.x, this.y);
     }
 };
 
@@ -150,23 +141,18 @@ Cursor.prototype.draw = function() {
  | Updates this Cursor's counters. |
 \*---------------------------------*/
 Cursor.prototype.update = function() {
-    // If this Cursor's animation counter has not yet elapsed,
     if (this.animationCounter < 24) {
-        // Then increment this Cursor's animation counter.
         this.animationCounter++;
     }
     else {
-        // Else, reset this Cursor's animation counter.
         this.animationCounter = 0;
     }
 
-    // If this Cursor's key counter is started and has not yet elapsed,
     if ((this.keyCounter > 0) && (this.keyCounter < 18)) {
-        this.keyCounter++; // Then increment this Cursor's key counter.
+        this.keyCounter++;
     }
-    // Else if this Cursor's key counter has elapsed,
     else if (this.keyCounter >= 18) {
-        this.keyCounter = 0; // Reset this Cursor's key counter.
+        this.keyCounter = 0;
     }
 };
 
@@ -174,11 +160,11 @@ Cursor.prototype.update = function() {
  | Generates a pothole. |
 \*----------------------*/
 var generatePothole = function() {
-   if (deersim.generator.vehicleCounter === 0) {         // If the vehicle counter has elapsed...
-      var pothole = deersim.generator.generatePothole(); // ...then attempt to generate a pothole.
+   if (deersim.generator.vehicleCounter === 0) {
+      var pothole = deersim.generator.generatePothole();
 
-      if (pothole !== null)               // If chance allows...
-         deersim.obstacles.push(pothole); // ...then push a new pothole onto the obstacles array.
+      if (pothole !== null)
+         deersim.obstacles.push(pothole);
    }
 };
 
@@ -189,50 +175,49 @@ var generatePothole = function() {
 // var getInput = function() {
 // #TODO -- documentation
 var getInput = function(dt) {
-   if ((deersim.state === "bossBattle") // If the player is playing a round or a boss battle...
+   if ((deersim.state === "bossBattle")
     || (deersim.state === "round")) {
-      // deer.getInput();          // ...then get key input for control of the active deer.
+      // deer.getInput();
       // #TODO -- documentation
-      deer.getInput(dt);          // ...then get key input for control of the active deer.
-      playerProfile.getInput(); // ...and get player input and convert to experience.
+      deer.getInput(dt);
+      playerProfile.getInput();
    }
 
-   var randomDecimal = Math.random(); // Generate a random decimal.
+   var randomDecimal = Math.random();
 
-   // Iterate through each key which is currently pressed.
    for (var key in keysDown) {
-      var value = Number(key); // Assign numeric wrapper of key to variable 'value'.
+      var value = Number(key);
 
       switch (value) { // #TODO -- consider functionalizing the repetitious sfx logic below
          case 13: // Key pressed is Enter.
-            if (deersim.state === "gameOver") { // If the game is displaying the game over screen,
-               startMainMenu(deersim);          // Transition to the main menu.
-               keyTimer++;                      // Start the key timer.
+            if (deersim.state === "gameOver") {
+               startMainMenu(deersim);
+               keyTimer++;
                pauseAndReplaySoundEffect(CONST_SOUND_INDEX_MENU_SELECTION_HIGH);
             }
-            else if ((deersim.state === "main")  // If the player is viewing the main menu...
-                  && (keyTimer === 0)) {         // ...and the key timer has elapsed...
-               if (deersim.mainMenuCursor.menuItem === 1) { // If the first option is selected...
-                  startRound();                             // ...then start a round of play.
-                  deersim.pauseTimer++;                     // ...start the pause timer.
+            else if ((deersim.state === "main")
+                  && (keyTimer === 0)) {
+               if (deersim.mainMenuCursor.menuItem === 1) {
+                  startRound();
+                  deersim.pauseTimer++;
                   pauseAndReplaySoundEffect(CONST_SOUND_INDEX_MENU_SELECTION_HIGH);
                }
-               else if (deersim.mainMenuCursor.menuItem === 2) { // If the second option is selected...
-                  showCreditsMenu = !showCreditsMenu;            // ...then invert flag to show credits...
-                  keyTimer++;                                    // ...and start the key timer.
+               else if (deersim.mainMenuCursor.menuItem === 2) {
+                  showCreditsMenu = !showCreditsMenu;
+                  keyTimer++;
                   pauseAndReplaySoundEffect(CONST_SOUND_INDEX_FRENCH_CANADIAN_GRUNT_2);
                }
-               else if (deersim.mainMenuCursor.menuItem === 3) { // If the third option is selected...
-                  if (deersim.obscenities === CONST_FALSE) {  // If obscenities are off...
-                     deersim.obscenities = CONST_TRUE;        // ...then turn them on.
-                     deersim.toggleBox.x = 1035;              // ...move the toggle box ro the right.
-                     keyTimer++;                              // ...and start the key timer.
+               else if (deersim.mainMenuCursor.menuItem === 3) {
+                  if (deersim.obscenities === CONST_FALSE) {
+                     deersim.obscenities = CONST_TRUE;
+                     deersim.toggleBox.x = 1035;
+                     keyTimer++;
                      pauseAndReplaySoundEffect(CONST_SOUND_INDEX_FRENCH_CANADIAN_GRUNT_2);
                   }
-                  else if (deersim.obscenities === CONST_TRUE) { // If obscenities are on...
-                     deersim.obscenities = CONST_FALSE;          // ...then turn them off.
-                     deersim.toggleBox.x = 961;                  // ...move the toggle box to the left.
-                     keyTimer++;                                 // ...and start the key timer.
+                  else if (deersim.obscenities === CONST_TRUE) {
+                     deersim.obscenities = CONST_FALSE;
+                     deersim.toggleBox.x = 961;
+                     keyTimer++;
                      pauseAndReplaySoundEffect(CONST_SOUND_INDEX_FRENCH_CANADIAN_GRUNT_1);
                   }
                }
@@ -241,58 +226,42 @@ var getInput = function(dt) {
          case 27: // Key pressed is Escape.
             if (((deersim.state === "round") || (deersim.state === "bossBattle"))
              && (deersim.pauseTimer === 0))
-                                  // If we are in the middle of a round
-                                  // And the pause timer has elapsed
-               pause();           // Then transition to the pause state
+               pause();
             else if ((deersim.state === "pause")
                   && (deersim.pauseTimer === 0))
-                                  // If we are paused,
-                                  // And the pause timer has elapsed
-               unpause();         // Then transition to the round state
+               unpause();
                break;
          case 76: // Key pressed is L.
-            if ((deersim.state !== "main")     // If the game is in a state other than the main menu...
-             && (deersim.state !== "pause")) { // ...or pause...
-               // If the active Deer is carrying the lightning powerup
-               // and the projectile delay has elapsed...
+            if ((deersim.state !== "main")
+             && (deersim.state !== "pause")) {
                if ((deer.powerup === "lightning")
                && (deersim.projectileCounter === 0)) {
-                  // Create a LightningBolt.
                   var lightningBolt = new LightningBolt(deer.x + 59, deer.lane);
 
-                  deersim.projectileCounter++; // Start the projectile counter.
+                  deersim.projectileCounter++;
 
-                  // Add the LightningBolt to the projectiles array.
                   deersim.projectiles.push(lightningBolt);
 
                   if (randomDecimal <= 0.33)
-                     pauseAndReplaySoundEffect(CONST_SOUND_INDEX_LIGHTNING_BOLT_LOW); // LightningBoltC#6
+                     pauseAndReplaySoundEffect(CONST_SOUND_INDEX_LIGHTNING_BOLT_LOW);
                   else if (randomDecimal <= 0.66)
-                     pauseAndReplaySoundEffect(CONST_SOUND_INDEX_LIGHTNING_BOLT_MID); // LightningBoltD#6
+                     pauseAndReplaySoundEffect(CONST_SOUND_INDEX_LIGHTNING_BOLT_MID);
                   else
-                     pauseAndReplaySoundEffect(CONST_SOUND_INDEX_LIGHTNING_BOLT_HIGH); // LightningBoltF6
+                     pauseAndReplaySoundEffect(CONST_SOUND_INDEX_LIGHTNING_BOLT_HIGH);
                }
             }
                break;
          case 87: // Key pressed is W.
-            // If the player is viewing the main menu,
             if (deersim.state === "main") {
-               // If the main menu cursor's key counter has elapsed,
-               // And the main menu cursor is pointed to an option
-               // underneath the uppermost option, then
                if ((deersim.mainMenuCursor.keyCounter === 0) && (deersim.mainMenuCursor.menuItem > 1)) {
-                  toggleMainMenuCursor(1); // Move the cursor up and play a sound effect.
+                  toggleMainMenuCursor(1);
                }
             }
                break;
          case 83: // Key pressed is S.
-            // If the player is viewing the main menu,
             if (deersim.state === "main") {
-               // If the main menu cursor's key counter has elapsed,
-               // And the main menu cursor is pointed to an option
-               // above the bottom option, then
                if ((deersim.mainMenuCursor.keyCounter === 0) && (deersim.mainMenuCursor.menuItem < 3)) {
-                  toggleMainMenuCursor(-1); // Move the cursor down and play a sound effect.
+                  toggleMainMenuCursor(-1);
                }
             }
                break;
@@ -305,34 +274,31 @@ var getInput = function(dt) {
  | from a Deer that's just been killed to the next Deer.   |
 \*---------------------------------------------------------*/
 var replaceDeer = function() {
-   // If the active deer has a powerup other than irradiation...
    if (deer.powerup !== "none") {
-      if (deer.powerup === "lightning") { // If the powerup is lightning...
-         deersim.soundEffects[CONST_SOUND_INDEX_DRUID_CHANT].pause();         // ...then pause the druid chant.
-         deersim.soundEffects[CONST_SOUND_INDEX_DRUID_CHANT].currentTime = 0; // ...and reset its playback position to zero.
+      if (deer.powerup === "lightning") {
+         deersim.soundEffects[CONST_SOUND_INDEX_DRUID_CHANT].pause();
+         deersim.soundEffects[CONST_SOUND_INDEX_DRUID_CHANT].currentTime = 0;
       } // #TODO -- implement cases for other powerups once they are implemented.
    }
 
-   var dyingDeer   = deer;              // Create a variable to assign the dying deer to.
+   var dyingDeer   = deer;
    // #TODO -- can the line below be removed?
-   dyingDeer.state = "dying";           // Set the dying Deer's state accordingly.
+   dyingDeer.state = "dying";
 
-   // If the player has extra Deer remaining,
    if (playerProfile.remainingDeer > 0) {
-      deer = new Deer();              // Then create a new Deer to set as active.
-      deersim.gameObjects.push(deer); // Add the newly created Deer to the game objects Array.
+      deer = new Deer();
+      deersim.gameObjects.push(deer);
 
-      // Decrement the count of Deer owned by the player Profile.
       playerProfile.changeRemainingDeer(-1);
 
-      if (deersim.state === "bossBattle") // If the player is fighting a boss...
-         boss.target = deer;      // ...then set the new deer as the boss's target.
+      if (deersim.state === "bossBattle")
+         boss.target = deer;
    }
    else {
-      if (deersim.state === "bossBattle") // If the player is fighting a boss...
-         boss.state = "exiting";  // ...then trigger that boss to exit the screen.
+      if (deersim.state === "bossBattle")
+         boss.state = "exiting";
 
-      startGameOverMenu(); // Otherwise, start the game over menu.
+      startGameOverMenu();
    }
 }
 
@@ -359,17 +325,14 @@ RoadSegment.prototype.update = function() {
  | @param int direction -- (1 = up), (-1 = down), (anything else = invalid)              |
 \*---------------------------------------------------------------------------------------*/
 var toggleMainMenuCursor = function(direction) {
-   const dyOptions = 30; // Vertical distance between menu options.
+   const dyOptions = 30;
 
-   deersim.mainMenuCursor.y        -= (dyOptions * direction); // Align cursor with its menu option.
-   deersim.mainMenuCursor.menuItem -= direction;               // (In/dec)rement, direction-dependent.
-   deersim.mainMenuCursor.keyCounter++;                        // Start the cursor's key counter.
+   deersim.mainMenuCursor.y        -= (dyOptions * direction);
+   deersim.mainMenuCursor.menuItem -= direction;
+   deersim.mainMenuCursor.keyCounter++;
 
-   /* Depending on which menu item the cursor lands on, pull the
-      correct sound effect object out of the sound effects array. */
    var soundEffect = deersim.soundEffects[3 + deersim.mainMenuCursor.menuItem];
 
-   // Pause (in case already playing), seek to t0, and play the sound effect.
    soundEffect.pause();
    soundEffect.currentTime = 0;
    soundEffect.play();
@@ -381,59 +344,47 @@ var toggleMainMenuCursor = function(direction) {
 // var update = function() {
 // #TODO -- documentation
 var update = function(dt) {
-   // If the debugger is enabled, then update it.
    if (deersim.debuggerEnabled === CONST_TRUE) {
       deersim.liveDebugger.update();
    }
 
-   // Update the touch manager first so that UI changes occur as quickly as possible.
    deersim.touchManager.update();
 
    if ((deersim.state === "bossBattle")
     || (deersim.state === "round")) {
-      collisionDetection();  // Perform collision detection.
-      vicinityDetection();   // Perform vicinity detection.
-      projectileDetection(); // Perform projectile detection.
+      collisionDetection();
+      vicinityDetection();
+      projectileDetection();
 
-      deersim.generator.update(); // Update the Generator.
+      deersim.generator.update();
 
-      // Update all of the game objects currently in play.
       for (var gameObject in deersim.gameObjects)
          // gameObjects[gameObject].update();
          deersim.gameObjects[gameObject].update(dt); // #TODO -- documentation
 
-      // Update all of the obstacles currently in play.
       for (var obstacle in deersim.obstacles)
          deersim.obstacles[obstacle].update();
 
-      // Update all of the powerups currently in play.
       for (var powerup in deersim.powerups)
          deersim.powerups[powerup].update();
 
-      // Update all of the projectiles currently in play.
       for (var projectile in deersim.projectiles)
          deersim.projectiles[projectile].update();
 
-      // Update all of the vehicles currently in play.
       for (var vehicle in deersim.vehicles)
          deersim.vehicles[vehicle].update();
 
-      // Remove all finished AnimationBlocks from the objects array.
       clearFinishedAnimations();
 
-      powerupDetection(); // Perform powerup detection.
+      powerupDetection();
 
-      if (deer.state === "dying") { // If the active Deer is dying...
-         replaceDeer();             // Then replace the active Deer with a new Deer.
+      if (deer.state === "dying") {
+         replaceDeer();
       }
 
-      playerProfile.update();                // Update the player profile.
-      playerProfile.locationMarker.update(); // Update the profile's cursor location marker.
+      playerProfile.update();
+      playerProfile.locationMarker.update();
 
-      /* Check the player profile's level to determine whether the player has just
-         levelled up. If they have, then execute the following series of conditional
-         checks. At specific levels, trigger the road manager's flags to open or close
-         new lanes as needed to manage the progression of the road through the environment. */
       if (playerProfile.level !== playerProfile.levelPreviousFrame) {
          if (playerProfile.level === 3) {
             deersim.roadManager.openBottomLaneRequested = CONST_TRUE;
@@ -449,15 +400,12 @@ var update = function(dt) {
          }
       }
 
-      /* Keep a rolling record of the player profile's level from
-         the previous game frame, in order to perform the check above. */
       playerProfile.levelPreviousFrame = playerProfile.level;
    }
 
-   if (deersim.state === "round") {  // If the player is currently playing a round,
-      kidnapDetection();     // Perform kidnap detection.
+   if (deersim.state === "round") {
+      kidnapDetection();
 
-      // Triggers Coop boss battle.
       if (playerProfile.consecutiveLvls >= 8) {
          startBossBattle();
       }
@@ -472,61 +420,52 @@ var update = function(dt) {
          preparePlayerForCoopsEntry();
       }
 
-      if (boss.hp <= 0) {      // If Coop has been killed...
-         boss.state = "dying"; // ...then set his state to dying.
+      if (boss.hp <= 0) {
+         boss.state = "dying";
          startRound();
       }
    }
 
-   if ((deersim.state === "gameOver") // If the game is presenting the game over menu,
-    || (deersim.state === "main")) {  // Or the main menu,
-      deersim.generator.update(); // Then update the Generator, and...
-      collisionDetection();       // Perform collision detection.
+   if ((deersim.state === "gameOver")
+    || (deersim.state === "main")) {
+      deersim.generator.update();
+      collisionDetection();
 
-      // Update all of the game objects currently in play.
       for (var gameObject in deersim.gameObjects) {
          deersim.gameObjects[gameObject].update();
       }
 
-      // Update all of the vehicles currently in play.
       for (var vehicle in deersim.vehicles) {
          deersim.vehicles[vehicle].update();
       }
 
-      // Update all of the obstacles currently in play.
       for (var obstacle in deersim.obstacles)
          deersim.obstacles[obstacle].update();
 
-      // Update all of the powerups currently in play.
       for (var powerup in deersim.powerups) {
          deersim.powerups[powerup].update();
       }
 
-      // Update all of the projectiles currently in play.
       for (var projectile in deersim.projectiles) {
          deersim.projectiles[projectile].update();
       }
 
-      // Remove all finished AnimationBlocks from the objects array.
       clearFinishedAnimations();
    }
 
    /* NOTE: This check & replay is included to mitigate the
       effects of bug 0001. See bugs.txt for more info.      */
    if (deersim.state === "main") {
-      // If the background track erroneously failed to start playing, play it.
       if ((deersim.musicCounter === 0)
        && (deersim.musicManager.backgroundTrack.currentTime === 0)) {
             deersim.musicManager.backgroundTrack.play();
          }
    }
 
-   // Even if the game is paused, the profile's cursor needs to update so that it can blink.
    if (deersim.state === "pause") {
       playerProfile.locationMarker.update();
    }
 
-   // Perform functions necessary to exit transition states.
    if (deersim.state === "transitionToSA40PhaseTwo")
       transitionToSA40PhaseTwo();
    if (deersim.state === "transitionToSA40PhaseFour")
@@ -538,10 +477,10 @@ var update = function(dt) {
    if (deersim.state === "transitionToSA40PhaseTen")
       transitionToSA40PhaseTen();
 
-   clearPassedObjects();               // Dispose of objects which have moved offscreen.
-   updateTimers();                     // Increment the animation timer.
-   deersim.backgroundManager.update(); // Update the background manager.
-   deersim.roadManager.update();       // Update the road manager.
+   clearPassedObjects();
+   updateTimers();
+   deersim.backgroundManager.update();
+   deersim.roadManager.update();
    clearExpiredGameObjects();
 }; // update()
 
@@ -556,36 +495,34 @@ var update = function(dt) {
  | occur no more frequently than once every 0.4 (24/60) seconds.  |
 \*----------------------------------------------------------------*/
 var updateTimers = function() {
-   if (deersim.state !== "pause") // If the game is not currently paused,
-      animationTimer++;   // Then increment the animation timer.
-   if (animationTimer >= 29) // If the animation timer has reached 29,
-      animationTimer = 0;    // reset it to 0.
+   if (deersim.state !== "pause")
+      animationTimer++;
+   if (animationTimer >= 29)
+      animationTimer = 0;
 
-   // If the kill counter is running...
    if ((deersim.killCounter > 0) && (deersim.killCounter < 18))
-      deersim.killCounter++; // ...then increment the kill counter.
-   if (deersim.killCounter >= 18) // If the kill counter has elapsed...
-      deersim.killCounter = 0;    // ...then reset the kill counter to 0.
+      deersim.killCounter++;
+   if (deersim.killCounter >= 18)
+      deersim.killCounter = 0;
 
-   if ((keyTimer > 0) && (keyTimer < 11)) // If the key timer is running,
-      keyTimer++;                         // Increment the key timer.
-   if (keyTimer >= 11) // If the key timer has elapsed,
-      keyTimer = 0;    // Reset the key timer to 0.
+   if ((keyTimer > 0) && (keyTimer < 11))
+      keyTimer++;
+   if (keyTimer >= 11)
+      keyTimer = 0;
 
-   deersim.musicCounter++; // Increment the music counter and reset it every half second.
+   deersim.musicCounter++;
    if (deersim.musicCounter >= 29)
       deersim.musicCounter = 0;
 
-   if ((deersim.pauseTimer > 0) && (deersim.pauseTimer < 30)) // If the pause timer is running,
-      deersim.pauseTimer++;                                   // Increment the pause timer.
-   if (deersim.pauseTimer >= 30) // If the pause timer has elapsed,
-      deersim.pauseTimer = 0;    // Reset the pause timer to 0.
+   if ((deersim.pauseTimer > 0) && (deersim.pauseTimer < 30))
+      deersim.pauseTimer++;
+   if (deersim.pauseTimer >= 30)
+      deersim.pauseTimer = 0;
 
-   // If the projectile counter is running...
    if ((deersim.projectileCounter > 0) && (deersim.projectileCounter < 24))
-      deersim.projectileCounter++; // ...then increment the projectile counter.
-   if (deersim.projectileCounter >= 24) // If the projectile counter has elapsed...
-      deersim.projectileCounter = 0;    // ...then reset the projectile counter.
+      deersim.projectileCounter++;
+   if (deersim.projectileCounter >= 24)
+      deersim.projectileCounter = 0;
 };
 
 // ---- End of function declarations. ----
@@ -608,7 +545,6 @@ var animate =  window.requestAnimationFrame
  | All game destruction code executes after the game loop has exited.    |
 \*-----------------------------------------------------------------------*/
 var gameLoop = function() {
-   // Add the current frame's time to the frame times array.
    deersim.frameTimes.push(Date.now());
    deersim.realTimeEngine = CONST_TRUE;
 
@@ -626,12 +562,12 @@ var gameLoop = function() {
             deersim.deltaT -= deersim.timeStep;
          }
 
-         draw(deersim.canvasContext); // Draw all game objects.
+         draw(deersim.canvasContext);
       }
       else {
-         getInput();                  // Get the user's key input for this iteration.
-         update();                    // Update all game objects.
-         draw(deersim.canvasContext); // Draw all game objects.
+         getInput();
+         update();
+         draw(deersim.canvasContext);
       }
    }
    catch (e) {
@@ -639,13 +575,11 @@ var gameLoop = function() {
       alert(e.message);
    }
 
-   // While there are frame times that are more than a full
-   // second old remaining in the frame times array...
    while (deersim.frameTimes[deersim.frameTimes.length - 1] - (deersim.frameTimes[0]) > 1000) {
-      deersim.frameTimes.splice(0, 1); // ...remove said old frames from the array.
+      deersim.frameTimes.splice(0, 1);
    }
 
-   animate(gameLoop);   // Execute next iteration of the game loop.
+   animate(gameLoop);
 };
 
 /*------------------------*\
@@ -654,41 +588,40 @@ var gameLoop = function() {
 var draw = function(canvasContext) {
    deersim.backgroundManager.bg1.draw();
    deersim.backgroundManager.bg2.draw();
-   deersim.roadManager.draw(); // Have the RoadManager draw all RoadSegments.
+   deersim.roadManager.draw();
 
-   for (var gameObject in deersim.gameObjects) { // Draw each game object currently in play.
+   for (var gameObject in deersim.gameObjects) {
       deersim.gameObjects[gameObject].draw();
    }
 
-   for (var vehicle in deersim.vehicles) { // Draw each vehicle currently in play.
+   for (var vehicle in deersim.vehicles) {
       deersim.vehicles[vehicle].draw();
    }
 
-   for (var obstacle in deersim.obstacles) { // Draw each obstacle currently in play.
+   for (var obstacle in deersim.obstacles) {
       deersim.obstacles[obstacle].draw();
    }
 
-   for (var powerup in deersim.powerups) { // Draw each powerup currently in play.
+   for (var powerup in deersim.powerups) {
       deersim.powerups[powerup].draw();
    }
 
-   for (var projectile in deersim.projectiles) { // Draw each projectile currently in play.
+   for (var projectile in deersim.projectiles) {
       deersim.projectiles[projectile].draw();
    }
 
-   // If the debugger is enabled, then draw its TextStrings to indicate game performance.
    if (deersim.debuggerEnabled) {
       deersim.liveDebugger.draw();
    }
 
    if (deersim.state === "main") {
       if (showCreditsMenu) {
-         deersim.creditsMenu.draw(); // Draw the credits menu.
+         deersim.creditsMenu.draw();
       }
    }
 
-   if (deersim.state !== "main") { // If the player is in any state other than the main menu...
-      playerProfile.draw(); // ...then draw the player profile.
+   if (deersim.state !== "main") {
+      playerProfile.draw();
    }
 };
 
@@ -716,14 +649,10 @@ window.addEventListener("touchend", function(touchEndEvent) {
    touchEndEvent.preventDefault(); // Cancel the default response to the touchend event.
 
    try {
-      /* Notify the TouchManager that this touchend
-         event is the most recent such event to occur. */
       deersim.touchManager.lastTouchEnded = touchEndEvent.changedTouches[0];
 
-      /* Notify the TouchManager of the time that this touchend event occurred. */
       deersim.touchManager.lastTouchEndedTS = Date.now();
 
-      /* Notify the TouchManager that it should process a swipe action. */
       deersim.touchManager.shouldProcessSwipe = CONST_TRUE;
    }
    catch (exception) {
@@ -736,21 +665,18 @@ window.addEventListener("touchend", function(touchEndEvent) {
  | Defines an event listener that responds to touchmove events. |
 \*--------------------------------------------------------------*/
 window.addEventListener("touchmove", function(touchMoveEvent) {
-   touchMoveEvent.preventDefault(); // Cancel the default response to the touchmove event.
+   touchMoveEvent.preventDefault();
 }, {passive: false}); // eventListener(touchmove)
 
 /*---------------------------------------------------------------*\
  | Defines an event listener that responds to touchstart events. |
 \*---------------------------------------------------------------*/
 window.addEventListener("touchstart", function(touchStartEvent) {
-   touchStartEvent.preventDefault(); // Cancel the default response to the touchstart event.
+   touchStartEvent.preventDefault();
 
    try {
-      /* Notify the TouchManager that this touchstart
-         event is the most recent such event to occur. */
       deersim.touchManager.lastTouchStarted = touchStartEvent.changedTouches[0];
 
-      /* Notify the TouchManager of the time that this touchstart event occurred. */
       deersim.touchManager.lastTouchStartedTS = Date.now();
    }
    catch (exception) {

--- a/deersim/generator.js
+++ b/deersim/generator.js
@@ -5,8 +5,8 @@
 \*----------------------------------------------------------------------*/
 
 function Generator() {
-   this.vehicleCounter = 0; // Initialize this Generator's vehicle counter.
-   this.powerupCounter = 0; // Initialize this Generator's powerup counter.
+   this.vehicleCounter = 0;
+   this.powerupCounter = 0;
 }
 
 /*--------------------------------------------------------------------------*\
@@ -16,14 +16,11 @@ function Generator() {
  | @returns int lane -- the lane value to be passed to a generated Vehicle. |
 \*--------------------------------------------------------------------------*/
 Generator.prototype.calculateLane = function() {
-   var randomDecimal = Math.random(); // Generate a random decimal.
+   var randomDecimal = Math.random();
 
-   // Calculate the number of lanes that the road manager is managing.
    var numLanes = (deersim.roadManager.maxLane - deersim.roadManager.minLane) + 1;
 
-   /* Depending on min/max lane, use the value of randomDecimal to
-      decide which lane the Vehicle/Powerup in question is generated in. */
-   if (numLanes === 3) { // When three active lanes, each has a 33% chance.
+   if (numLanes === 3) {
       if (randomDecimal < 0.33)
          return deersim.roadManager.minLane;
       else if ((randomDecimal >= 0.33) && (randomDecimal < 0.66))
@@ -31,7 +28,7 @@ Generator.prototype.calculateLane = function() {
       else if (randomDecimal >= 0.66)
          return (deersim.roadManager.minLane + 2);
    }
-   else if (numLanes === 4) { // When four active lanes, each has a 25% chance.
+   else if (numLanes === 4) {
       if (randomDecimal < 0.25)
          return deersim.roadManager.minLane;
       else if ((randomDecimal >= 0.25) && (randomDecimal < 0.5))
@@ -41,7 +38,7 @@ Generator.prototype.calculateLane = function() {
       else if (randomDecimal >= 0.75)
          return (deersim.roadManager.minLane + 3);
    }
-   else if (numLanes === 5) { // When five active lanes, each has a 20% chance.
+   else if (numLanes === 5) {
       if (randomDecimal < 0.2)
          return deersim.roadManager.minLane;
       else if ((randomDecimal >= 0.2) && (randomDecimal < 0.4))
@@ -63,19 +60,19 @@ Generator.prototype.calculateLane = function() {
  | @returns int speed -- the speed value to be passed to a generated Vehicle. |
 \*----------------------------------------------------------------------------*/
 Generator.prototype.calculateSpeed = function() {
-   var randomDecimal = Math.random(); // Generate a random decimal.
+   var randomDecimal = Math.random();
 
-   if (randomDecimal < 0.25) { // If the random decimal is between 0 and 0.25,
-      return 3;               // Return a speed value of 3
+   if (randomDecimal < 0.25) {
+      return 3;
    }
    else if ((randomDecimal >= 0.25) && (randomDecimal < 0.5)) {
-      return 4; // Else if the random decimal is between 0.25 and 0.5,
-   }             // Return a speed value of 4
+      return 4;
+   }
    else if ((randomDecimal >= 0.5) && (randomDecimal < 0.75)) {
-      return 5; // Else if the random decimal is between 0.5 and 0.75,
-   }             // Return a speed value of 5
-   else {        // Else if the random decimal is between 0.75 and 1,
-      return 6; // Return a speed value of 6
+      return 5;
+   }
+   else {
+      return 6;
    }
 }; // calculateSpeed
 
@@ -85,9 +82,8 @@ Generator.prototype.calculateSpeed = function() {
  | @returns <any> boss -- the newly generated boss.             |
 \*--------------------------------------------------------------*/
 Generator.prototype.generateBoss = function() {
-   // If the current environment is I-84...
    if (deersim.backgroundManager.environment === CONST_ENVIRONMENT_I84) {
-      return new Coop(); // ...then generate a Coop for the player to fight.
+      return new Coop();
    }
 };
 
@@ -95,17 +91,15 @@ Generator.prototype.generateBoss = function() {
  | Generates a Pothole with 40% probability. Otherwise, returns null. |
 \*--------------------------------------------------------------------*/
 Generator.prototype.generatePothole = function() {
-   var randomDecimal = Math.random(); // Generate a random decimal.
-   
-   // If the random decimal is within the desired range...
+   var randomDecimal = Math.random();
+
    if ((randomDecimal >= 0.3)
     && (randomDecimal < 0.7)) {
-      // ...then generate and return a Pothole.
       var pothole = new Pothole(this.calculateLane());
       return pothole;
    }
    else
-      return null; // ...otherwise, return null.
+      return null;
 };
 
 /*--------------------------------------------------------------*\
@@ -114,15 +108,13 @@ Generator.prototype.generatePothole = function() {
  | @returns <any> powerup -- the newly generated powerup.       |
 \*--------------------------------------------------------------*/
 Generator.prototype.generatePowerup = function() {
-   var randomDecimal = Math.random(); // Generate a random decimal.
-   
+   var randomDecimal = Math.random();
+
    // #TODO -- modify the frequency with which powerups are generated.
-   // Use the random decimal to determine the powerup type.
    if (randomDecimal < 0.5) {
-      // Create a new LightningRobe.
       return new LightningRobe(this.calculateLane());
    }
-   else { // Create a new Irradiation.
+   else {
       return new Irradiation(this.calculateLane());
    }
 }
@@ -133,10 +125,8 @@ Generator.prototype.generatePowerup = function() {
  | @returns <any> vehicle -- the newly generated vehicle.       |
 \*--------------------------------------------------------------*/
 Generator.prototype.generateVehicle = function() {
-   var randomDecimal = Math.random(); // Generate a random decimal.
-   
-   // Based off of the environment and the random decimal,
-   // Determine which vehicle will be returned by this function.
+   var randomDecimal = Math.random();
+
    if (deersim.backgroundManager.environment === CONST_ENVIRONMENT_I84) {
       if (randomDecimal < 0.11)
          return new Vehicle(this.calculateLane(), this.calculateSpeed(),
@@ -191,7 +181,7 @@ Generator.prototype.generateVehicle = function() {
       else
          return new DeerTruck(this.calculateLane(), this.calculateSpeed());
    }
-   
+
    return new WeenieMobile(this.calculateLane(), this.calculateSpeed());
 };
 
@@ -199,31 +189,29 @@ Generator.prototype.generateVehicle = function() {
  | Updates this Generator. |
 \*-------------------------*/
 Generator.prototype.update = function() {
-   this.vehicleCounter++; // Increment this Generator's vehicle counter.
-   this.powerupCounter++; // Increment this Generator's powerup counter.
+   this.vehicleCounter++;
+   this.powerupCounter++;
 
-   if (this.vehicleCounter === 58) { // If this Generator's vehicle counter has elapsed,
-      if (deersim.state === "bossBattle") { // If the player is fighting a boss...
-         var potholeBuffer = generatePothole(); // Generate a potential Pothole.
-         
-         if (potholeBuffer instanceof Pothole)     // If there was a real Pothole generated...
-            deersim.obstacles.push(potholeBuffer); // ...add it to the obstacles array.
+   if (this.vehicleCounter === 58) {
+      if (deersim.state === "bossBattle") {
+         var potholeBuffer = generatePothole();
+
+         if (potholeBuffer instanceof Pothole)
+            deersim.obstacles.push(potholeBuffer);
       }
       else
-         deersim.vehicles.push(this.generateVehicle()); // Otherwise, generate a new vehicle.
-      
-      // Reset this Generator's vehicle counter.
+         deersim.vehicles.push(this.generateVehicle());
+
       this.vehicleCounter = 0;
    }
 
-   if (this.powerupCounter === 29) { // If this Generator's powerup counter has elapsed,
-                                     // Then generate a random decimal.
+   if (this.powerupCounter === 29) {
       var randomDecimal = Math.random();
 
-      if (randomDecimal < 0.1) {                // With a 10% probability...
-         deersim.powerups.push(this.generatePowerup()); // Generate a new powerup.
+      if (randomDecimal < 0.1) {
+         deersim.powerups.push(this.generatePowerup());
       }
 
-      this.powerupCounter = 0; // Reset this Generator's powerup counter.
+      this.powerupCounter = 0;
    }
 };

--- a/deersim/getI84SimContent.js
+++ b/deersim/getI84SimContent.js
@@ -7,12 +7,12 @@ function getI84SimContent()
            width="64" height="64" src="deersim/images/bagDeerStill.png" hidden>
       <img id="SA40Background"
            width="1280" height="720" src="deersim/images/sa40Background.png" hidden>
-      
+
       <img id="BossHPBarBackRectangle"
            width="256" height="256" src="deersim/images/bossHPBarBackRectangle.png" hidden>
       <img id="ConnecticutMap"
            width="246" height="234" src="deersim/images/connecticutMap.png" hidden>
-      
+
       <img id="Coop"
            width="128" height="128" src="deersim/images/coop128.png" hidden>
       <img id="Coop_C_0"
@@ -39,7 +39,7 @@ function getI84SimContent()
            width="128" height="128" src="deersim/images/coop128_C_300.png" hidden>
       <img id="Coop_C_330"
            width="128" height="128" src="deersim/images/coop128_C_330.png" hidden>
-      
+
       <img id="DeerHead"
            width="32" height="32" src="deersim/images/deerHead.png" hidden>
 
@@ -310,7 +310,7 @@ function getI84SimContent()
            width="32" height="32" src="deersim/images/numberBlock8.png" hidden>
       <img id="NumberBlock9"
            width="32" height="32" src="deersim/images/numberBlock9.png" hidden>
-      
+
       <img id="Road"
            width="1280" height="216" src="deersim/images/road.png" hidden>
       <img id="RoadLane"
@@ -329,7 +329,7 @@ function getI84SimContent()
            width="128" height="40" src="deersim/images/roadSegmentOpeningTop.png" hidden>
       <img id="RoadSideTopSegment"
            width="128" height="6" src="deersim/images/roadSideTopSegment.png" hidden>
-      
+
       <img id="SmallMono!"
            width="16" height="16" src="deersim/images/smallMono!.png" hidden>
       <img id="SmallMono$"
@@ -702,14 +702,14 @@ function getI84SimContent()
            width="16" height="16" src="deersim/images/tinyConsolasYLversion.png" hidden>
       <img id="ToggleBox"
            width="128" height="128" src="deersim/images/toggleBox.png" hidden>
-      
+
       <img id="WhiteVan"
            width="128" height="128" src="deersim/images/whiteVan128.png" hidden>
       <img id="Yorig512"
            width="512" height="512" src="deersim/images/yorigPortrait.png"hidden>
       <img id="YorigsSpeechBalloon"
            width="115" height="58" src="deersim/images/yorigsSpeechBalloon.png"hidden>
-      
+
       <canvas id="deersimcanvas" width="1280" height="720"
               style="position:     absolute;
                      margin-left:  auto;
@@ -717,7 +717,7 @@ function getI84SimContent()
                      left:         0;
                      right:        0;
                      top:          0px"></canvas>
-      
+
       <p style="text-align: center;
                 font-family: verdana;
                 font-size: 30px;
@@ -727,7 +727,7 @@ function getI84SimContent()
                 left: 0;
                 right: 0;
                 top: 700px">I-84 Simulator for "the Internet"<sup>TM</sup></p>
-      
+
       <a href="ReleaseNotes.txt"
          style="text-align: center;
                 font-family: verdana;
@@ -738,7 +738,7 @@ function getI84SimContent()
                 left: 0;
                 right: 0;
                 top: 890px">Release Notes</a>
-      
+
       <p style="text-align: center;
                 font-family: verdana;
                 font-size: 10px;

--- a/deersim/initializeGame.js
+++ b/deersim/initializeGame.js
@@ -3,47 +3,46 @@
 \*-------------------------------------------*/
 function initializeGame(a_deersim)
 {
-    a_deersim.gameObjects  = new Array(); // Stores game objects currently in play.
-    a_deersim.vehicles     = new Array(); // Stores vehicles currently in play.
-    a_deersim.obstacles    = new Array(); // Stores obstacles currently in play.
-    a_deersim.powerups     = new Array(); // Stores powerups currently in play.
-    a_deersim.projectiles  = new Array(); // Stores projectiles currently in play.
-    a_deersim.soundEffects = new Array(); // Stores the game's sound effects.
-    a_deersim.voices       = new Array(); // Stores the game's voices (i.e. sound clips).
+    a_deersim.gameObjects  = new Array();
+    a_deersim.vehicles     = new Array();
+    a_deersim.obstacles    = new Array();
+    a_deersim.powerups     = new Array();
+    a_deersim.projectiles  = new Array();
+    a_deersim.soundEffects = new Array();
+    a_deersim.voices       = new Array();
 
     populateJavascriptArrayWithAudioFromHtmlContainer("soundEffects", a_deersim.soundEffects); // TODO: Magic values.
 
-    a_deersim.obscenities    = CONST_FALSE; // Initialize the game with obscenities turned off.
+    a_deersim.obscenities    = CONST_FALSE;
     a_deersim.realTimeEngine = CONST_TRUE; // #TODO -- documentation
 
     populateJavascriptArrayWithAudioFromHtmlContainer("voices", a_deersim.voices); // TODO: Magic values.
 
-    a_deersim.generator         = new Generator();                         // Initialize the generator.
-    a_deersim.messageGenerator  = new MessageGenerator();                  // Initialize the MessageGenerator.
-    a_deersim.backgroundManager = new BackgroundManager();                 // Initialize the BackgroundManager.
-    a_deersim.musicManager      = new MusicManager(CONST_ENVIRONMENT_I84); // Initialize the MusicManager.
-    a_deersim.roadManager       = new RoadManager();                       // Initialize the RoadManager.
-    a_deersim.touchManager      = new TouchManager();                      // Initialize the TouchManager.
+    a_deersim.generator         = new Generator();
+    a_deersim.messageGenerator  = new MessageGenerator();
+    a_deersim.backgroundManager = new BackgroundManager();
+    a_deersim.musicManager      = new MusicManager(CONST_ENVIRONMENT_I84);
+    a_deersim.roadManager       = new RoadManager();
+    a_deersim.touchManager      = new TouchManager();
 
-    // Initialize the credits menu.
     a_deersim.creditsMenu = new TextBox(((CONST_CANVAS_WIDTH / 2) - 224), 108);
     // #TODO -- 224 is half of the credits menu width. Find a way to not hardcode it.
 
     a_deersim.debuggerEnabled = CONST_FALSE;
 
-    a_deersim.frameTimes = new Array(); // Stores all frame times in ms, during the past second.
+    a_deersim.frameTimes = new Array();
 
-    a_deersim.liveDebugger = new LiveDebugger(a_deersim); // Initialize the debugger.
+    a_deersim.liveDebugger = new LiveDebugger(a_deersim);
 
-    a_deersim.musicCounter      = 0; // Initialize the music counter.
-    a_deersim.pauseTimer        = 0; // Initialize the pause timer.
-    a_deersim.killCounter       = 0; // Initialize the kill counter.
-    a_deersim.projectileCounter = 0; // Initialize the projectile counter.
+    a_deersim.musicCounter      = 0;
+    a_deersim.pauseTimer        = 0;
+    a_deersim.killCounter       = 0;
+    a_deersim.projectileCounter = 0;
     a_deersim.deltaT            = 0; // #TODO -- documentation
 
     a_deersim.timeStep = 1000 / 60; // #TODO -- documentation
 
-    a_deersim.killCounter++; // Start the kill counter.
+    a_deersim.killCounter++;
 }; // initializeGame
 
 function populateJavascriptArrayWithAudioFromHtmlContainer(containerId, arrayToPopulate)

--- a/deersim/liveDebugger.js
+++ b/deersim/liveDebugger.js
@@ -9,10 +9,10 @@
 // ---- Start of object declarations. ----
 
 function LiveDebugger(a_deersim) {
-   var marginX = 15; // Add a 15-pixel margin between the text and canvas' edge, horizontally.
-   var marginY = 5;  // Add a 5-pixel margin in between each line of text, vertically.
+   var marginX = 15;
+   var marginY = 5;
 
-   { // Initialize TextStrings indicating the game's performance in FPS.
+   {
       this.FPS = new TextString(
          marginX + (CONST_FONT_SIZE_SMALL * 16), // x, w/ 16 character indent
          0,                                      // y
@@ -32,7 +32,7 @@ function LiveDebugger(a_deersim) {
          );
    }
 
-   { // Initialize TextStrings indicating the number of game objects in play.
+   {
       this.numObjects = new TextString(
          marginX,                           // x
          (CONST_FONT_SIZE_SMALL + marginY), // y
@@ -41,7 +41,7 @@ function LiveDebugger(a_deersim) {
          "NUMBER OF OBJECTS  :",            // string
          "Small"                            // size
          );
-      
+
       this.numObjectsCtr = new TextString(
          marginX + (CONST_FONT_SIZE_SMALL * 20),  // x, w/ 20 character indent
          (CONST_FONT_SIZE_SMALL + marginY),       // y
@@ -52,7 +52,7 @@ function LiveDebugger(a_deersim) {
          );
    }
 
-   { // Initialize TextStrings indicating the number of vehicles in play.
+   {
       this.numVehicles = new TextString(
          marginX,                                     // x
          (CONST_FONT_SIZE_SMALL * 2) + (marginY * 2), // y
@@ -61,7 +61,7 @@ function LiveDebugger(a_deersim) {
          "NUMBER OF VEHICLES :",                      // string
          "Small"                                      // size
          );
-      
+
       this.numVehiclesCtr = new TextString(
          marginX + (CONST_FONT_SIZE_SMALL * 20),      // x, w/ 20 character indent
          (CONST_FONT_SIZE_SMALL * 2) + (marginY * 2), // y
@@ -72,7 +72,7 @@ function LiveDebugger(a_deersim) {
          );
    }
 
-   { // Initialize TextStrings indicating the number of obstacles in play.
+   {
       this.numObstacles = new TextString(
          marginX,                                     // x
          (CONST_FONT_SIZE_SMALL * 3) + (marginY * 3), // y
@@ -81,7 +81,7 @@ function LiveDebugger(a_deersim) {
          "NUMBER OF OBSTACLES:",                      // string
          "Small"                                      // size
          );
-      
+
       this.numObstaclesCtr = new TextString(
          (CONST_FONT_SIZE_SMALL * 20) + marginX,        // x, w/ 20 character indent
          ((CONST_FONT_SIZE_SMALL * 3) + (marginY * 3)), // y
@@ -92,7 +92,7 @@ function LiveDebugger(a_deersim) {
          );
    }
 
-   { // Initialize TextStrings indicating the number of segments scanned by certain algorithms.
+   {
       this.segmentsScanned = new TextString(
          marginX + (CONST_FONT_SIZE_SMALL * 3),       // x, w/ 3 character indent
          (CONST_FONT_SIZE_SMALL * 4) + (marginY * 4), // y
@@ -101,9 +101,9 @@ function LiveDebugger(a_deersim) {
          "SEGMENTS SCANNED:",                         // string
          "Small"                                      // size
          );
-      
+
       this.segmentCounter = 0; // Initialize the count of road segments scanned.
-      
+
       this.segmentsScannedCtr = new TextString(
          marginX + (CONST_FONT_SIZE_SMALL * 20),      // x, w/ 20 character indent
          (CONST_FONT_SIZE_SMALL * 4) + (marginY * 4), // y
@@ -114,7 +114,7 @@ function LiveDebugger(a_deersim) {
          );
    }
 
-   { // Initialize TextStrings indicating the number of active road segments.
+   {
       this.activeSegments = new TextString(
          marginX + (CONST_FONT_SIZE_SMALL * 4),       // x, w/ 4 character indent
          (CONST_FONT_SIZE_SMALL * 5) + (marginY * 5), // y
@@ -145,22 +145,22 @@ function LiveDebugger(a_deersim) {
 \*-----------------------------------------------------*/
 LiveDebugger.prototype.draw = function() {
    this.FPS.draw();
-   this.FPSCtr.draw();             // Display frames per second.
+   this.FPSCtr.draw();
 
    this.numObjects.draw();
-   this.numObjectsCtr.draw();      // Display number of active game objects.
+   this.numObjectsCtr.draw();
 
    this.numVehicles.draw();
-   this.numVehiclesCtr.draw();     // Display number of active vehicles.
+   this.numVehiclesCtr.draw();
 
    this.numObstacles.draw();
-   this.numObstaclesCtr.draw();    // Display number of active obstacles.
+   this.numObstaclesCtr.draw();
 
    this.segmentsScanned.draw();
-   this.segmentsScannedCtr.draw(); // Display number of road segments being scanned.
+   this.segmentsScannedCtr.draw();
 
    this.activeSegments.draw();
-   this.activeSegmentsCtr.draw();  // Display number of active road segments.
+   this.activeSegmentsCtr.draw();
 }; // LiveDebugger.draw()
 
 /*-------------------------------------------------------------------*\
@@ -170,25 +170,25 @@ LiveDebugger.prototype.draw = function() {
 LiveDebugger.prototype.update = function() {
    this.FPSCtr.updateWithStringOverwrite(
       deersim.frameTimes.length.toString()
-      ); // Update frames per second.
+      );
 
    this.numObjectsCtr.updateWithStringOverwrite(
       deersim.gameObjects.length.toString()
-      ); // Update number of active game objects.
+      );
 
    this.numVehiclesCtr.updateWithStringOverwrite(
       deersim.vehicles.length.toString()
-      ); // Update number of active vehicles.
+      );
 
    this.numObstaclesCtr.updateWithStringOverwrite(
       deersim.obstacles.length.toString()
-      ); // Update number of active obstacles.
+      );
 
    this.segmentsScannedCtr.updateWithStringOverwrite(
       this.segmentCounter.toString()
-      ); // Update number of road segments being scanned.
+      );
 
    this.activeSegmentsCtr.updateWithStringOverwrite(
       deersim.roadManager.roadSegments.length.toString()
-      ); // Update number of active road segments.
+      );
 }; // LiveDebugger.update()

--- a/deersim/managers.js
+++ b/deersim/managers.js
@@ -12,10 +12,9 @@
  | active Deer is covering distance while running along the road.       |
 \*----------------------------------------------------------------------*/
 function BackgroundManager() {
-   this.environment   = CONST_ENVIRONMENT_I84; // Set this BgM's environment to the default, I-84.
-   this.bgIsScrolling = CONST_TRUE;            // By default, the BgM tells Backgrounds to scroll.
-   
-   // Create two adjacent Background objects for this BackgroundManager to own.
+   this.environment   = CONST_ENVIRONMENT_I84;
+   this.bgIsScrolling = CONST_TRUE;
+
    this.bg1 = new Background(0, "Background");
    this.bg2 = new Background(CONST_CANVAS_WIDTH, "Background");
 }; // BackgroundManager()
@@ -25,10 +24,9 @@ function BackgroundManager() {
  | loading and functionality of background music. |
 \*------------------------------------------------*/
 function MusicManager(environment) {
-   this.environment = environment; // Assign this MusicManager's environment.
-   this.loadMusic();               // Load a background track based on the environment.
-   
-   // Flag to track when necessary to load new music after a boss defeats a player.
+   this.environment = environment;
+   this.loadMusic();
+
    this.reloadOnNextMain = CONST_TRUE;
 }; // MusicManager()
 
@@ -40,14 +38,10 @@ function MusicManager(environment) {
  | StaticMenuObjects which represent the shoulders of the active Road.          |
 \*------------------------------------------------------------------------------*/
 function RoadManager() {
-   /* The RoadManager manages three arrays containing segments of road that scroll
-      at the active Deer's running speed. Respectively, these arrays contain...    */
-   this.roadSegments   = new Array(); // ...road segments comprising the road's five lanes.
-   this.bottomSegments = new Array(); // ...road segments comprising the road's bottom shoulder.
-   this.topSegments    = new Array(); // ...road segments comprising the road's top shoulder.
+   this.roadSegments   = new Array();
+   this.bottomSegments = new Array();
+   this.topSegments    = new Array();
 
-   /* generateFlags contains five boolean 'generate'
-      flags signalling RoadSegment generation per lane. */
    this.generateFlags    = new Array();
    this.generateFlags[CONST_LANE_0_INDEX] = CONST_FALSE;
    this.generateFlags[CONST_LANE_1_INDEX] = CONST_TRUE;
@@ -55,22 +49,14 @@ function RoadManager() {
    this.generateFlags[CONST_LANE_3_INDEX] = CONST_TRUE;
    this.generateFlags[CONST_LANE_4_INDEX] = CONST_FALSE;
 
-   /* This RoadManager owns four flags that control the opening
-      (i.e. beginning) and closing (i.e. ending) of the road's lanes. When
-      initializing this RoadManager, start by setting all flags to false. */
    this.closeBottomLaneRequested = CONST_FALSE; // Set to true when the bottom lane should close.
    this.closeTopLaneRequested    = CONST_FALSE; // Set to true when the top lane should close.
    this.openBottomLaneRequested  = CONST_FALSE; // Set to true when a new bottom lane should open.
    this.openTopLaneRequested     = CONST_FALSE; // Set to true when a new top lane should open.
 
-   /* Member variables used by other game objects to define
-      lane-based boundaries for object movement and generation. */
    this.maxLane = 4;
    this.minLane = 2;
 
-   /* Lanes that are 'idle' are usually sandwiched in the middle,
-      and should display statically without any RoadSegments
-      generated. idleFlags indicates which lanes are currently idle. */
    this.idleFlags    = new Array();
    this.idleFlags[CONST_LANE_0_INDEX] = CONST_FALSE;
    this.idleFlags[CONST_LANE_1_INDEX] = CONST_FALSE;
@@ -78,8 +64,6 @@ function RoadManager() {
    this.idleFlags[CONST_LANE_3_INDEX] = CONST_FALSE;
    this.idleFlags[CONST_LANE_4_INDEX] = CONST_FALSE;
 
-   /* Idle lanes are drawn using StaticMenuObjects, which
-      live in this RoadManager's idleLanes array.         */
    this.idleLanes = new Array();
    for (var lane = 0; lane <= 4; lane++) {
       this.idleLanes[lane] = new StaticMenuObject(
@@ -100,9 +84,6 @@ function RoadManager() {
    this.sideHeightBottom = this.kBottomHeightMid; // The y position of the bottom side of the Road.
    this.sideHeightTop    = this.kTopHeightMid;    // The y position of the top side of the Road.
 
-   /* A two-dimensional for loop is used to create an initial set of 50 RoadSegments.
-      However, all RoadSegments are stored in a one-dimensional array, since
-      distribution of active RoadSegments will vary throughout gameplay.              */
    var arrayIndex = 0;
    var numColumns = 10;
    var numLanes   = 5;
@@ -117,12 +98,10 @@ function RoadManager() {
                row - 1                                               // lane
             );
 
-         arrayIndex++; // For each 2D element, keep track of its position in the 1D array.
+         arrayIndex++;
       }
    }
 
-   /* A one-dimensional for loop is used to create initial
-      sets of 10 top RoadSegments and 10 bottom RoadSegments. */
    for (var column = 0; column < numColumns; column++) {
       this.bottomSegments[column] =
          new RoadSegment(
@@ -150,14 +129,11 @@ function RoadManager() {
  | device. The TouchManager only supports a single touch occuring at one time. |
 \*-----------------------------------------------------------------------------*/
 function TouchManager() {
-   this.lastTouchEnded     = -1; // Will point to the most recent HTML touchend event.
-   this.lastTouchEndedTS   = -1; // Will point to the time the most recent touchend occurred.
-   this.lastTouchStarted   = -1; // Will point to the most recent HTML touchstart event.
-   this.lastTouchStartedTS = -1; // Will point to the time the most recent touchstart occurred.
+   this.lastTouchEnded     = -1;
+   this.lastTouchEndedTS   = -1;
+   this.lastTouchStarted   = -1;
+   this.lastTouchStartedTS = -1;
 
-   /* Initialize a flag to raise when this TouchManager should process a swipe
-      action. If the user touches the screen, then moves somewhere, then removes
-      their finger from the screen, then a swipe action should be processed.     */
    this.shouldProcessSwipe = CONST_FALSE;
 }; // TouchManager()
 
@@ -185,8 +161,8 @@ BackgroundManager.prototype.generateBackgrounds = function() {
  | Sets the BackgroundManager's environment and generates new Background objects. |
 \*--------------------------------------------------------------------------------*/
 BackgroundManager.prototype.setEnvironment = function(environment) {
-   this.environment = environment; // Assign this BackgroundManager's environment.
-   this.generateBackgrounds();     // Generate new Background objects.
+   this.environment = environment;
+   this.generateBackgrounds();
 }; // BackgroundManager.setEnvironment()
 
 /*------------------------------------------------------------------------*\
@@ -195,13 +171,11 @@ BackgroundManager.prototype.setEnvironment = function(environment) {
  | BackgroundManager moves that Background offscreen to the right.        |
 \*------------------------------------------------------------------------*/
 BackgroundManager.prototype.update = function() {
-   // If Background #1 moves offscreen to the left,
    if (this.bg1.x < -CONST_CANVAS_WIDTH)
-      this.bg1.x = this.bg2.x + CONST_CANVAS_WIDTH; // Move Background #1 offscreen to the right.
-   
-   // If Background #2 moves offscreen to the left,
+      this.bg1.x = this.bg2.x + CONST_CANVAS_WIDTH;
+
    if (this.bg2.x < -CONST_CANVAS_WIDTH)
-      this.bg2.x = this.bg1.x + CONST_CANVAS_WIDTH; // Move Background #2 offscreen to the right.
+      this.bg2.x = this.bg1.x + CONST_CANVAS_WIDTH;
 
    if (this.bgIsScrolling) {
       this.bg1.x -= 3;
@@ -216,10 +190,8 @@ BackgroundManager.prototype.update = function() {
 \*----------------------------------------------------------------*/
 // TODO: Consider just making the MusicManager aware of its owning deersim object.
 MusicManager.prototype.createAndDisplayMusicTicker = function(a_deersim) {
-   // Create a handle which will be used to determine the music ticker box's size.
    var musicTickerBoxHandle = "Ticker box handle not found.";
 
-   // Assign the handle for the desired size, based on the length of the background track ID.
    // #TODO -- explore the possibility of determining size based on ID length, programmatically.
    // #TODO -- single-source these string constants since
    //           they're also used in MusicManager.prototype.loadMusic().
@@ -248,14 +220,12 @@ MusicManager.prototype.createAndDisplayMusicTicker = function(a_deersim) {
          break;
    }
 
-   // Create a dialog box in which to display the background track ID to the player.
    var musicTickerBox = new StaticMenuObject(
       5,                   // x
       5,                   // y
       musicTickerBoxHandle // imageHandle
       );
 
-   // Create a TextString representation of the background track ID to show to the player.
    var musicTickerText = new TextString(
       15,                     // x
       15,                     // y
@@ -276,14 +246,14 @@ MusicManager.prototype.createAndDisplayMusicTicker = function(a_deersim) {
 // Change this implementation accordingly so that I
 // can load schizoid.wav for the Coop boss battle.
 MusicManager.prototype.loadMusic = function() {
-   var randomDecimal = Math.random(); // Generate a random decimal.
+   var randomDecimal = Math.random();
 
-   if (this.environment === CONST_ENVIRONMENT_I84) { // If this MusicManager's environment is I-84...
+   if (this.environment === CONST_ENVIRONMENT_I84) {
       if (randomDecimal < 0.25) {
          this.backgroundTrack   = document.getElementById("DeersimClassicTheme");
          this.backgroundTrackID = "I-84 Simulator Theme (Classic)";
       }
-      else if (randomDecimal < 0.50) { 
+      else if (randomDecimal < 0.50) {
          this.backgroundTrack   = document.getElementById("MrWsNewSegway");
          this.backgroundTrackID = "entropics - 'mr. w~s new segway (I-84 Simulator for 'the Internet' Remix)'";
       }
@@ -296,7 +266,7 @@ MusicManager.prototype.loadMusic = function() {
          this.backgroundTrackID = "Cornelius Squatgood - 'startlingly, ||YOURFEARISREAL|| & in_another_time'";
       }
    }
-   else if (this.environment === "sa40") { // If this MusicManager's environment is SA-40...
+   else if (this.environment === "sa40") {
       if (randomDecimal < 0.5) {
          this.backgroundTrack   = document.getElementById("PreviewOfYourDeathTerlinguaSun");
          this.backgroundTrackID = "Cornelius Squatgood - 'preview of your death / terlingua sun'";
@@ -306,9 +276,9 @@ MusicManager.prototype.loadMusic = function() {
          this.backgroundTrackID = "Cornelius Squatgood - 'it seems i~ve wandered into the wrong bakery again'";
       }
    }
-   
-   this.backgroundTrack.loop = true; // Set this MusicManager's background track to loop.
-   
+
+   this.backgroundTrack.loop = true;
+
    // this.backgroundTrack.play(); // Play the loaded background track.
 }; // MusicManager.loadMusic()
 
@@ -316,24 +286,20 @@ MusicManager.prototype.loadMusic = function() {
  | Draws every RoadSegment, plus both RoadSide objects, owned by this RoadManager. |
 \*---------------------------------------------------------------------------------*/
 RoadManager.prototype.draw = function() {
-   // Draw all lane RoadSegments owned by this RoadManager.
    for (var roadSegment in this.roadSegments) {
       this.roadSegments[roadSegment].draw();
    }
 
-   // Draw all idle lanes owned by this RoadManager.
    for (var idleLane in this.idleLanes) {
       if (this.idleFlags[idleLane] === CONST_TRUE) {
          this.idleLanes[idleLane].draw();
       }
    }
 
-   // Draw all bottom RoadSegments owned by this RoadManager.
    for (var bottomSegment in this.bottomSegments) {
       this.bottomSegments[bottomSegment].draw();
    }
 
-   // Draw all top RoadSegments owned by this RoadManager.
    for (var topSegment in this.topSegments) {
       this.topSegments[topSegment].draw();
    }
@@ -344,16 +310,11 @@ RoadManager.prototype.draw = function() {
  | lanes should receive new RoadSegments, how many, and their type.       |
 \*------------------------------------------------------------------------*/
 RoadManager.prototype.generateNewRoadSegments = function() {
-   for (var lane = 0; lane <= 4; lane++) { // For each lane, from bottom (0) to top (4)...
-      /* If the lane's generate flag is asserted, then execute a series of conditional checks
-         to determine exactly what type of RoadSegment should be generated in this lane.      */
+   for (var lane = 0; lane <= 4; lane++) {
       if (this.generateFlags[lane]) {
-         /* If considering the bottom lane and the 'close' flag is raised,
-            then close the lane by pushing two new RoadSegments (a diagonal
-            one, then a rectangular one) into the road segments array.      */
          if ((this.closeBottomLaneRequested === CONST_TRUE)
           && (lane === (this.minLane - 1))) {
-            this.roadSegments.push( // Diagonal segment
+            this.roadSegments.push(
                new RoadSegment(
                   this.maxXValue + this.segmentWidth,                  // x
                   this.sideHeightBottom - (this.segmentHeight * lane), // y
@@ -362,7 +323,7 @@ RoadManager.prototype.generateNewRoadSegments = function() {
                   )
                );
 
-            this.roadSegments.push( // Rectangular segment
+            this.roadSegments.push(
                new RoadSegment(
                   this.maxXValue + this.segmentWidth,          // x
                   (this.sideHeightBottom - this.segmentHeight)
@@ -372,14 +333,11 @@ RoadManager.prototype.generateNewRoadSegments = function() {
                   )
                );
 
-            this.closeBottomLaneRequested = CONST_FALSE; // Reset the close flag.
+            this.closeBottomLaneRequested = CONST_FALSE;
          }
-         /* If considering the top lane and the 'close' flag is raised,
-            then close the lane by pushing two new RoadSegments (a rectangular
-            one, then a diagonal one) into the road segments array.            */
          else if ((this.closeTopLaneRequested === CONST_TRUE)
                && (lane === (this.maxLane - 1))) {
-            this.roadSegments.push( // Rectangular segment
+            this.roadSegments.push(
                new RoadSegment(
                   this.maxXValue + this.segmentWidth,          // x
                   (this.sideHeightBottom - this.segmentHeight)
@@ -389,7 +347,7 @@ RoadManager.prototype.generateNewRoadSegments = function() {
                   )
                );
 
-            this.roadSegments.push( // Diagonal segment
+            this.roadSegments.push(
                new RoadSegment(
                   this.maxXValue + this.segmentWidth,                // x
                   (this.sideHeightBottom - (this.segmentHeight * 2))
@@ -399,10 +357,8 @@ RoadManager.prototype.generateNewRoadSegments = function() {
                   )
                );
 
-            this.closeTopLaneRequested = CONST_FALSE; // Reset the close flag.
+            this.closeTopLaneRequested = CONST_FALSE;
          }
-         /* If considering the bottom lane and the 'open' flag is raised, then open
-            a new lane by pushing a diagonal RoadSegment into the road segments array. */
          else if ((this.openBottomLaneRequested === CONST_TRUE)
           && (lane === (this.minLane - 1))) {
             this.roadSegments.push(
@@ -415,10 +371,8 @@ RoadManager.prototype.generateNewRoadSegments = function() {
                   )
                );
 
-            this.openBottomLaneRequested = CONST_FALSE; // Reset the open flag.
+            this.openBottomLaneRequested = CONST_FALSE;
          }
-         /* If considering the top lane and the 'open' flag is raised, then open
-            a new lane by pushing a diagonal RoadSegment into the road segments array. */
          else if ((this.openTopLaneRequested === CONST_TRUE)
                && (lane === (this.maxLane - 1))) {
             this.roadSegments.push(
@@ -431,15 +385,15 @@ RoadManager.prototype.generateNewRoadSegments = function() {
                   )
                );
 
-            this.openTopLaneRequested = CONST_FALSE; // Reset the open flag.
+            this.openTopLaneRequested = CONST_FALSE;
          }
-         else { // ...otherwise, generate a standard RoadSegment in this lane.
+         else {
             // #TODO -- documentation
             // Ideally, in order to fix up the documentation of this section
             // I will need to define a new member constant for the lane 0 base y value.
             if ((lane == (this.maxLane - 1))
-            || (lane == (this.minLane - 1))) { // For only the top and bottom lanes...
-               this.roadSegments.push( // Push a new standard RoadSegment into the array
+            || (lane == (this.minLane - 1))) {
+               this.roadSegments.push(
                   new RoadSegment(
                      this.maxXValue + this.segmentWidth,                   // x
                      (CONST_LANE_0_BASE - 8) - (CONST_LANE_HEIGHT * lane), // y
@@ -472,96 +426,69 @@ RoadManager.prototype.update = function() {
    this.newTopSegmentsNeeded    = CONST_FALSE; // Triggers new top RoadSegment generation.
    this.newBottomSegmentsNeeded = CONST_FALSE; // Triggers new bottom RoadSegment generation.
 
-   // Iterate through every active standard RoadSegment.
    for (var roadSegment in this.roadSegments) {
-      this.roadSegments[roadSegment].update(); // Update all RoadSegments.
+      this.roadSegments[roadSegment].update();
 
-      // Keep a running watch on the max X value, i.e. farthest-right standard RoadSegment.
       if (this.roadSegments[roadSegment].x > this.maxXValue) {
          this.maxXValue = this.roadSegments[roadSegment].x;
       }
 
-      /* Keep a running watch on the min X value and its array index,
-         i.e. a watch on the farthest-left standard RoadSegment. */
       if (this.roadSegments[roadSegment].x < this.minXValue) {
          this.minXValue        = this.roadSegments[roadSegment].x;
          this.indexOfMinXValue = roadSegment;
       }
    }
 
-   // Iterate through every active bottom RoadSegment.
    for (var bottomSegment in this.bottomSegments) {
       this.bottomSegments[bottomSegment].update();
 
-      // Keep a running watch on the max X value, i.e. farthest-right bottom RoadSegment.
       if (this.bottomSegments[bottomSegment].x > this.bottomMaxXValue) {
          this.bottomMaxXValue = this.bottomSegments[bottomSegment].x;
       }
 
-      /* Keep a running watch on the min X value and its array index,
-         i.e. a watch on the farthest-left bottom RoadSegment. */
       if (this.bottomSegments[bottomSegment].x < this.bottomMinXValue) {
          this.bottomMinXValue = this.bottomSegments[bottomSegment].x;
          this.indexOfBottomMinXValue = bottomSegment;
       }
    }
 
-   // Iterate through every active top RoadSegment.
    for (var topSegment in this.topSegments) {
       this.topSegments[topSegment].update();
 
-      // Keep a running watch on the max X value, i.e. farthest-right top RoadSegment.
       if (this.topSegments[topSegment].x > this.topMaxXValue) {
          this.topMaxXValue = this.topSegments[topSegment].x;
       }
 
-      /* Keep a running watch on the min X value and its array index,
-         i.e. a watch on the farthest-left top RoadSegment. */
       if (this.topSegments[topSegment].x < this.topMinXValue) {
          this.topMinXValue = this.topSegments[topSegment].x;
          this.indexOfTopMinXValue = topSegment;
       }
    }
 
-   /* If the farthest-left standard RoadSegment has crossed
-      the removal boundary, then remove it from the array.  */
    if (this.minXValue < this.removalBoundary) {
       this.roadSegments.splice(this.indexOfMinXValue, 1);
    }
 
-   /* If the farthest-left bottom RoadSegment has crossed
-      the removal boundary, then remove it from the array.  */
    if (this.bottomMinXValue < this.removalBoundary) {
       this.bottomSegments.splice(this.indexOfBottomMinXValue, 1);
    }
 
-   /* If the farthest-left top RoadSegment has crossed
-      the removal boundary, then remove it from the array.  */
    if (this.topMinXValue < this.removalBoundary) {
       this.topSegments.splice(this.indexOfTopMinXValue, 1);
    }
 
-   /* If the farthest-right standard RoadSegments will no longer cover the
-      Road horizontally, then signal the need for new standard RoadSegments. */
    if (this.maxXValue < this.creationBoundary) {
       this.newSegmentsNeeded = CONST_TRUE;
    }
 
-   /* If the farthest-right bottom RoadSegments will no longer cover the
-      Road horizontally, then signal the need for new bottom RoadSegments. */
    if (this.bottomMaxXValue < this.creationBoundary) {
       this.newBottomSegmentsNeeded = CONST_TRUE;
    }
 
-   /* If the farthest-right top RoadSegments will no longer cover the
-      Road horizontally, then signal the need for new top RoadSegments. */
    if (this.topMaxXValue < this.creationBoundary) {
       this.newTopSegmentsNeeded = CONST_TRUE;
    }
 
-   /* If during a round of play, then reset the player profile's
-      road-associated variables in order to define a programmed
-      sequence of road conditions based on the player's current level. */
    if (deersim.state === "round") {
       if (playerProfile.level < 3) {
          this.generateFlags[CONST_LANE_0_INDEX] = CONST_FALSE;
@@ -601,21 +528,15 @@ RoadManager.prototype.update = function() {
       }
    }
 
-   // If new road segments are needed, generate them.
    if (this.newSegmentsNeeded) {
       this.generateNewRoadSegments();
    }
 
-   /* If we've decided that it's time to add a new top RoadSegment,
-      then let's make sure that's true and that there isn't a reason not to. */
    if (this.newTopSegmentsNeeded) {
-      // Establish a reference to the top-right RoadSegment.
       var topRightRoadSegment = this.roadSegments[
          this.roadSegments.length - 1
          ];
 
-      /* Check the top-right RoadSegment to see if it is an opening or closing lane.
-         If it is not, then push a new top RoadSegment into the top road segments array. */
       if ((topRightRoadSegment.type !== "openingTopLane")
        && (topRightRoadSegment.type !== "closingTopLane")) {
          this.topSegments.push(
@@ -629,27 +550,15 @@ RoadManager.prototype.update = function() {
       }
    }
 
-   /* If we've decided that it's time to add a new bottom RoadSegment,
-      then let's make sure that's true and that there isn't a reason not to.*/
    if (this.newBottomSegmentsNeeded) {
-      /* Establish a reference to the RoadSegment that we
-         expect to be the bottom-right RoadSegment.       */
       var bottomRightRoadSegment = this.roadSegments[
          this.roadSegments.length - 2
          ];
 
-      /* Next, establish a reference to the RoadSegment one prior to
-         that. In the case where a bottom lane is closing, there will
-         be one diagonal RoadSegment below the 'bottom-right' RoadSegment,
-         which we'll refer to as the 'sub-bottom-right' RoadSegment. */
       var subBottomRightRoadSegment = this.roadSegments[
          this.roadSegments.length - 3
          ];
 
-      /* Check the bottom-right RoadSegment to see if it is an opening
-         lane, and check the sub-bottom-right RoadSegment to see if it
-         is a closing lane. If neither of these conditions is true, then
-         push a new bottom RoadSegment into the bottom road segments array. */
       if ((bottomRightRoadSegment.type !== "openingBottomLane")
        && (subBottomRightRoadSegment.type !== "closingBottomLane")) {
          this.bottomSegments.push(
@@ -670,36 +579,24 @@ RoadManager.prototype.update = function() {
  | immediately, but this update function runs (in theory) at 60 FPS.     |
 \*-----------------------------------------------------------------------*/
 TouchManager.prototype.update = function() {
-   // If this TouchManager should process a swipe, then check the game's current state.
    if (this.shouldProcessSwipe === CONST_TRUE) {
-      if (deersim.state === "main") { // If the player is viewing the main menu...
-         // Calculation the duration of the swipe, in milliseconds.
-         var swipeDuration = 
+      if (deersim.state === "main") {
+         var swipeDuration =
             ((deersim.touchManager.lastTouchEndedTS - deersim.touchManager.lastTouchStartedTS)
                / CONST_MS_PER_SEC);
 
-         // Define a minimum and maximum swipe duration, in seconds.
          var minSwipeDuration = 0.1;
          var maxSwipeDuration = 1;
 
-         /* Check to see whether the swipe being processing was in between
-            the minimum and maximum swipe durations. If it was, continue
-            processing the swipe. If not, abort processing the swipe.      */
          var shouldChangeMenu = CONST_FALSE;
          if ((swipeDuration > minSwipeDuration) && (swipeDuration < maxSwipeDuration)) {
             shouldChangeMenu = CONST_TRUE;
          }
 
          if (shouldChangeMenu === CONST_TRUE) {
-            /* Calculate the swipe rise, or the vertical distance that the swipe
-               covered. Because the y-axis is top-to-bottom, the swipe rise will be
-               negative for an upward swipe, and positive for a downward swipe.     */
             var swipeRise =
                (deersim.touchManager.lastTouchEnded.pageY - deersim.touchManager.lastTouchStarted.pageY);
 
-            /* Initialize a variable to use as a switch indicating desired
-               direction, plus a pixel threshold for the swipe rise. If
-               the swipe rise is significant, assign it a direction.       */
             var direction = 0;
             var threshold = 100;
             if (swipeRise < -threshold)
@@ -708,17 +605,11 @@ TouchManager.prototype.update = function() {
                direction = -1;
 
             if (direction === 1) {
-               /* If the main menu cursor's key counter has elapsed,
-                  And the main menu cursor is pointed to an option
-                  underneath the uppermost option, then toggle the cursor up one. */
                if ((deersim.mainMenuCursor.keyCounter === 0) && (deersim.mainMenuCursor.menuItem > 1)) {
                   toggleMainMenuCursor(1);
                }
             }
             else if (direction === -1) {
-               /* If the main menu cursor's key counter has elapsed,
-                  And the main menu cursor is pointed to an option
-                  above the bottom option, then toggle the cursor down one. */
                if ((deersim.mainMenuCursor.keyCounter === 0) && (deersim.mainMenuCursor.menuItem < 3)) {
                   toggleMainMenuCursor(-1);
                }
@@ -726,7 +617,7 @@ TouchManager.prototype.update = function() {
          }
       }
 
-      this.shouldProcessSwipe = CONST_FALSE; // Reset this flag for future use.
+      this.shouldProcessSwipe = CONST_FALSE;
    }
 }; // TouchManager.update()
 

--- a/deersim/messageGenerator.js
+++ b/deersim/messageGenerator.js
@@ -11,7 +11,7 @@ var line3; // Third line of message, in TextString form.
 var line4; // Fourth line of message, in TextString form.
 
 function MessageGenerator() {
-   this.randomDecimal = 0; // Initialize this MessageGenerator's random decimal.
+   this.randomDecimal = 0;
 };
 
 /*-----------------------------------------------------------------------*\
@@ -20,11 +20,10 @@ function MessageGenerator() {
  |                                     comprising the game over message. |
 \*-----------------------------------------------------------------------*/
 MessageGenerator.prototype.gameOverMessage = function() {
-   var lines = new Array(); // Create an array to store all TextStrings.
-   
-   this.randomDecimal = Math.random(); // Generate a new random decimal.
-   
-   // Assign four lines based on the random decimal generated.
+   var lines = new Array();
+
+   this.randomDecimal = Math.random();
+
    if (this.randomDecimal < 0.25) {
       line1 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              235,
@@ -32,21 +31,21 @@ MessageGenerator.prototype.gameOverMessage = function() {
                              "default",
                              "It is not in the nature of the",
                              "Small");
-                             
+
       line2 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              260,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              "          deer to give up",
                              "Small");
-                             
+
       line3 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              285,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              "   from the writings of Yorig",
                              "Small");
-                             
+
       line4 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              310,
                              CONST_FONT_SIZE_SMALL,
@@ -61,21 +60,21 @@ MessageGenerator.prototype.gameOverMessage = function() {
                              "default",
                              "Impossible! A deer will simply not stay",
                              "Small");
-                             
+
       line2 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              260,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              " irradiated for more than seven seconds!",
                              "Small");
-                             
+
       line3 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              285,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              "      from the writings of Yorig",
                              "Small");
-                             
+
       line4 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              310,
                              CONST_FONT_SIZE_SMALL,
@@ -90,21 +89,21 @@ MessageGenerator.prototype.gameOverMessage = function() {
                              "default",
                              "x633------------------FATAL ERRO",
                              "Small");
-                             
+
       line2 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              260,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              "   $ | $ || $ | $ ||| $ |",
                              "Small");
-                             
+
       line3 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              285,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              "R TRANSMISSIONS ERROR FOR MORE INF",
                              "Small");
-                             
+
       line4 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              310,
                              CONST_FONT_SIZE_SMALL,
@@ -119,21 +118,21 @@ MessageGenerator.prototype.gameOverMessage = function() {
                              "default",
                              "   HELLO PLEASED TO SEE YOU ARE ENJOYING",
                              "Small");
-                             
+
       line2 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              260,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              "         YOU     ARE ENJOYING  THE GAME",
                              "Small");
-                             
+
       line3 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              285,
                              CONST_FONT_SIZE_SMALL,
                              "default",
                              "                        - MIKE (DEV)",
                              "Small");
-                             
+
       line4 = new TextString(((CONST_CANVAS_WIDTH / 2) - (20 * CONST_FONT_SIZE_SMALL)),
                              310,
                              CONST_FONT_SIZE_SMALL,
@@ -141,12 +140,11 @@ MessageGenerator.prototype.gameOverMessage = function() {
                              " P.S. PLEASE USE GAMESHARK FOR ENHANCES",
                              "Small");
    }
-   
-   // Add each line to the lines array.
+
    lines.push(line1);
    lines.push(line2);
    lines.push(line3);
    lines.push(line4);
-   
+
    return lines;
 };

--- a/deersim/obstacles.js
+++ b/deersim/obstacles.js
@@ -15,15 +15,13 @@
  | and present a similar threat to the active Deer.       |
 \*--------------------------------------------------------*/
 function Pothole(lane) {
-   this.lane           = lane;                  // Assign this Pothole's lane.
-   this.speed          = 3;                     // Default speed.
-   this.d              = CONST_FONT_SIZE_SMALL; // Default Pothole dimension.
+   this.lane           = lane;
+   this.speed          = 3;
+   this.d              = CONST_FONT_SIZE_SMALL;
    this.collisionWidth = 8;    // #TODO -- change this when I implement the proper sprite.
-   
-   // Assign this Pothole's x position as adjacent to the canvas boundary.
+
    this.x = CONST_CANVAS_WIDTH - this.d;
-   
-   // Assign this Pothole's y position based on its lane.
+
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane) - 64;
 };
 
@@ -43,7 +41,7 @@ Pothole.prototype.draw = function() {
  | Updates this Pothole. |
 \*-----------------------*/
 Pothole.prototype.update = function() {
-   this.x -= this.speed; // Move this Pothole to the left, proportional to its speed.
+   this.x -= this.speed;
 };
 
 // ---- End of function declarations. ----

--- a/deersim/physics.js
+++ b/deersim/physics.js
@@ -12,66 +12,51 @@
  | This routine runs once per game loop iteration.       |
 \*-------------------------------------------------------*/
 var collisionDetection = function() {
-   for (var vehicle in deersim.vehicles) { // For all vehicles currently in play,
+   for (var vehicle in deersim.vehicles) {
       if ((deersim.state === "round")
       || (deersim.state === "bossBattle")) {
-         if (!(deersim.vehicles[vehicle] instanceof Coop)) { // ...(except for Coops)...
-            // If this vehicle is colliding with the currently active Deer,
-            // And the currently active Deer is not irradiated,
+         if (!(deersim.vehicles[vehicle] instanceof Coop)) {
             if (hasCollisionOccurred(deer, deersim.vehicles[vehicle])
             && (deer.powerup !== "irradiated")) {
-               deer.state = "dying";                                       // Set the active Deer's state to dying.
-               deersim.soundEffects[CONST_SOUND_INDEX_DEER_SHRIEK].play(); // Play the deer shriek sound effect.
+               deer.state = "dying";
+               deersim.soundEffects[CONST_SOUND_INDEX_DEER_SHRIEK].play();
 
-               clearPowerupBars(); // Remove any active powerup Bars from play.
+               clearPowerupBars();
 
-               // Change the player profile's damage by the vehicle's value,
-               // and store the vehicle's value in a variable.
                collisionValue = Math.floor(playerProfile.changeDamage(deersim.vehicles[vehicle].value));
 
-               collisionString = CONST_TRUE; // Signal the need for a collision TextString.
+               collisionString = CONST_TRUE;
 
-               // If the vehicle is a DeerTruck...
                if (deersim.vehicles[vehicle] instanceof DeerTruck) {
-                  // ...then grant the player profile one deer.
                   playerProfile.changeRemainingDeer(1);
                }
             }
 
-            // If this vehicle is colliding with the currently active Deer...
-            // ...and the kill counter has elapsed...
-            // ...and the currently active Deer is irradiated,
             if ((hasCollisionOccurred(deer, deersim.vehicles[vehicle]))
             && (deersim.killCounter === 0)
             && (deer.powerup === "irradiated")) {
-               deersim.vehicles[vehicle].state = "dying"; // ...then set this vehicle's state to dying.
+               deersim.vehicles[vehicle].state = "dying";
 
-               deersim.killCounter++; // Start the kill counter.
+               deersim.killCounter++;
 
-               // Change the player profile's damage by the vehicle's value,
-               // and store the vehicle's value in a variable.
                collisionValue = Math.floor(playerProfile.changeDamage(deersim.vehicles[vehicle].value));
 
-               collisionString = CONST_TRUE; // Signal the need for a collision TextString.
+               collisionString = CONST_TRUE;
 
-               // If the vehicle is a DeerTruck...
                if (deersim.vehicles[vehicle] instanceof DeerTruck) {
-                  // ...then grant the player profile one deer.
                   playerProfile.changeRemainingDeer(1);
                }
             }
          }
       }
 
-      // Check for approaching vehicles, adjust their speed if found.
       isVehicleBeingApproached(deersim.vehicles[vehicle]);
    }
 
-   if (collisionString) { // If there is need for a collision TextString...
-      // Create a collision TextString, and add it to the objects array.
+   if (collisionString) {
       deersim.gameObjects.push(new TextString(deer.x, deer.y - 64, CONST_FONT_SIZE_SMALL, "pickup", "$" + collisionValue, "Small"));
 
-      collisionString = false; // Unsignal the need for a collision TextString.
+      collisionString = false;
    }
 };
 
@@ -80,20 +65,19 @@ var collisionDetection = function() {
  | other 'vehicles', which are really potholes. |
 \*----------------------------------------------*/
 var collisionDetectionForCoopBattle = function() {
-   if (hasCollisionOccurred(deer, boss)   // If the active deer and Coop collide...
-    && (deer.powerup !== "irradiated")) { // ...and the active deer is not irradiated...
-      deer.state = "dying";                                       // Set the active Deer's state to dying.
-      deersim.soundEffects[CONST_SOUND_INDEX_DEER_SHRIEK].play(); // Play the deer shriek sound effect.
-      clearPowerupBars();                                         // Remove any active powerup Bars from play.
+   if (hasCollisionOccurred(deer, boss)
+    && (deer.powerup !== "irradiated")) {
+      deer.state = "dying";
+      deersim.soundEffects[CONST_SOUND_INDEX_DEER_SHRIEK].play();
+      clearPowerupBars();
    }
 
-   // Cycle through each Pothole in play, and if one is colliding with Coop...
    for (obstacle in deersim.obstacles)
       if ((deersim.obstacles[obstacle] instanceof Pothole)
        && (hasCollisionOccurred(boss, deersim.obstacles[obstacle]))
        && (boss.hitCounter === 0)) {
-         boss.hp -= 5;      // ...then decrement his hit points by 5...
-         boss.hitCounter++; // ...and start his hit counter.
+         boss.hp -= 5;
+         boss.hitCounter++;
       }
 };
 
@@ -107,38 +91,31 @@ var collisionDetectionForCoopBattle = function() {
  |                                          gameObject are colliding. |
 \*--------------------------------------------------------------------*/
 var hasCollisionOccurred = function(activeDeer, gameObject) {
-   var xOverlap = 0; // Stores TRUE if both objects overlap horizontally.
-   var sameLane = 0; // Stores TRUE if both objects occupy the same lane.
+   var xOverlap = 0;
+   var sameLane = 0;
 
-   // If both objects occupy the same lane,
    if (activeDeer.lane === gameObject.lane) {
-      sameLane = 1; // Then assert variable 'sameLane'.
+      sameLane = 1;
    }
 
-   // Assign the visible maximum X value for the Deer.
    var deerMaxX = activeDeer.x + CONST_DEER_WIDTH;
 
-   // Assign the visible maximum X value for the game object.
    var gameObjectMaxX = gameObject.x + gameObject.collisionWidth;
 
-   // Test #1 for deer and game object x overlap:
    if ((gameObject.x < deerMaxX) && (deerMaxX < gameObjectMaxX)) {
       xOverlap = 1;
    }
 
-   // Test #2 for deer and game object x overlap:
    if ((gameObject.x < activeDeer.x) && (activeDeer.x < gameObjectMaxX)) {
       xOverlap = 1;
    }
 
-   // If both objects occupy the same lane and overlap,
-   // And the active Deer is not currently initializing,
    if (sameLane && xOverlap
     && (activeDeer.state !== "initializing")) {
-      return 1; // Return true.
+      return 1;
    }
    else {
-      return 0; // Return false.
+      return 0;
    }
 };
 
@@ -150,16 +127,10 @@ var hasCollisionOccurred = function(activeDeer, gameObject) {
  | @param <any> vehicle1 -- the vehicle tested for approachers    |
 \*----------------------------------------------------------------*/
 var isVehicleBeingApproached = function(vehicle1) {
-    // For every vehicle currently in play, check...
     for (var vehicle2 in deersim.vehicles) {
-        // ...if both vehicles occupy the same lane
-        // ...if vehicle 2 is to the right of vehicle 1
-        // ...if vehicle 2 is close to vehicle 1
-
         if ((vehicle1.lane === deersim.vehicles[vehicle2].lane)
          && (deersim.vehicles[vehicle2].x > vehicle1.x)
          && (deersim.vehicles[vehicle2].x <= (vehicle1.x + 150)) ) {
-            // If all true, set vehicle 2's speed equal to vehicle 1's speed.
             deersim.vehicles[vehicle2].speed = vehicle1.speed;
         }
     }
@@ -171,27 +142,26 @@ var isVehicleBeingApproached = function(vehicle1) {
  | range, this function initiates the transition to SA-40. |
 \*---------------------------------------------------------*/
 var kidnapDetection = function() {
-   var whiteVan; // Create a variable to store an active WhiteVan.
+   var whiteVan;
 
-    for (var vehicle in deersim.vehicles) {                // For every vehicle currently in play,
-      if (deersim.vehicles[vehicle] instanceof WhiteVan) { // If the vehicle is a WhiteVan,
-         whiteVan = deersim.vehicles[vehicle];		       // Then assign the WhiteVan as active.
+    for (var vehicle in deersim.vehicles) {
+      if (deersim.vehicles[vehicle] instanceof WhiteVan) {
+         whiteVan = deersim.vehicles[vehicle];
 
-         // If the active Deer is within the active WhiteVan's kidnapping range,
          if ((deer.x >= (whiteVan.x + 25))
           && (deer.x <= (whiteVan.x + 35))
           && (deer.lane === 5)) {
-            for (soundEffect in deersim.soundEffects) {           // For every sound effect...
-               deersim.soundEffects[soundEffect].pause();         // ...pause in case already playing.
-               deersim.soundEffects[soundEffect].currentTime = 0; // ...and re-seek to t0.
+            for (soundEffect in deersim.soundEffects) {
+               deersim.soundEffects[soundEffect].pause();
+               deersim.soundEffects[soundEffect].currentTime = 0;
             }
 
-            loadMusic( // ...then load the SA-40 transition theme music.
+            loadMusic(
                "SA-40 Transition", // bgTrack
                "SA-40 Transition"  // bgTrackID
                );
 
-            transitionToSA40PhaseOne();    // ...and start phase one of the transition to SA-40.
+            transitionToSA40PhaseOne();
          }
       }
    }
@@ -202,42 +172,39 @@ var kidnapDetection = function() {
  | colliding with the active deer. If so, the deer picks up that powerup.   |
 \*--------------------------------------------------------------------------*/
 var powerupDetection = function() {
-   var i = 0; // Initialize counter for powerup detection algorithm.
+   var i = 0;
 
-   while (i < deersim.powerups.length) { // Iterate through each powerup in play.
+   while (i < deersim.powerups.length) {
 
-      if ((deer.state === "active")    // If the active Deer is colliding with any powerup...
+      if ((deer.state === "active")
        && (hasCollisionOccurred(deer, deersim.powerups[i]))
-       && (deer.powerup === "none")) { // ...and doesn't already have a powerup...
+       && (deer.powerup === "none")) {
          if (deersim.powerups[i] instanceof LightningRobe) {
-            deer.pickupPowerup("lightning"); // Instruct the active Deer to pick up the powerup.
+            deer.pickupPowerup("lightning");
 
-            var starburst = new Starburst( // Create an "ENLIGHTENED!" Starburst.
+            var starburst = new Starburst(
                deer.x,                                      // x
                deer.y - (CONST_DIM_XLARGE - deer.dim) - 20, // y
                "Enlightened",                               // imageHandle
                "enlightened"                                // purpose
                );
 
-            // Add the new Starburst to the game objects array and play its sound effect.
             deersim.gameObjects.push(starburst);
             deersim.soundEffects[CONST_SOUND_INDEX_DRUID_CHANT].play();
 
-            // Create a SpeakingYorig to alert the player to the 'L' key, to fire lightning.
             var speakingYorig = new SpeakingYorig();
             deersim.gameObjects.push(speakingYorig);
          }
          else if (deersim.powerups[i] instanceof Irradiation) {
-            deer.pickupPowerup("irradiated"); // Instruct the active Deer to pick up the powerup.
+            deer.pickupPowerup("irradiated");
 
-            var starburst = new Starburst( // Create an "IRRADIATED!" Starburst.
+            var starburst = new Starburst(
                deer.x,                                      // x
                deer.y - (CONST_DIM_XLARGE - deer.dim) - 20, // y
                "Irradiated",                                // imageHandle
                "irradiated"                                 // purpose
                );
 
-            // Add the new Starburst to the game objects array and play its sound effect.
             deersim.gameObjects.push(starburst);
             deersim.soundEffects[CONST_SOUND_INDEX_VOX_COMET_SOUND_CHECK].play();
          }
@@ -245,7 +212,7 @@ var powerupDetection = function() {
          pauseAndReplaySoundEffect(CONST_SOUND_INDEX_OBTAIN_POWERUP);
       }
 
-      i++; // Iterate counter.
+      i++;
    }
 }; // powerupDetection
 
@@ -255,24 +222,19 @@ var powerupDetection = function() {
  | of projectile/vehicle combinations. If so, the projectile kills that vehicle. |
 \*-------------------------------------------------------------------------------*/
 var projectileDetection = function() {
-   var ptI = 0; // Initialize counter for projectiles.
-   var vhI = 0; // Initialize counter for vehicles.
+   var ptI = 0;
+   var vhI = 0;
 
-   while (ptI < deersim.projectiles.length) { // Iterate through each projectile in play.
-      while (vhI < deersim.vehicles.length) { // Iterate through each vehicle in play.
-         // If this projectile is colliding with this vehicle...
-         // ...and the kill counter has elapsed...
+   while (ptI < deersim.projectiles.length) {
+      while (vhI < deersim.vehicles.length) {
          if ((hasCollisionOccurred(deersim.projectiles[ptI], deersim.vehicles[vhI]))
           && (deersim.killCounter === 0)) {
-            deersim.vehicles[vhI].state = "dying"; // ...then set the vehicle's state to dying.
-            deersim.killCounter++;                         // ...and start the kill counter.
+            deersim.vehicles[vhI].state = "dying";
+            deersim.killCounter++;
 
-            // Change the player profile's damage by the vehicle's value,
-            // and store the vehicle's value in a variable.
             collisionValue = Math.floor(
                playerProfile.changeDamage(deersim.vehicles[vhI].value));
 
-            // Create a collision TextString, and add it to the objects array.
             deersim.gameObjects.push(new TextString(deersim.projectiles[ptI].x,
                                             deer.y - 64,
                                             CONST_FONT_SIZE_SMALL,
@@ -281,10 +243,10 @@ var projectileDetection = function() {
                                             "Small"));
          }
 
-         vhI++; // Iterate the vehicle counter.
+         vhI++;
       }
 
-      ptI++; // Iterate the projectile counter.
+      ptI++;
    }
 };
 
@@ -294,18 +256,14 @@ var projectileDetection = function() {
 \*------------------------------------------------------------------*/
 var vicinityDetection = function() {
    for (var vehicle in deersim.vehicles) {
-      // For each vehicle, if it is close to the active deer and in an adjacent lane...
       if ((Math.abs(deersim.vehicles[vehicle].x - deer.x) <= 10)
        && (Math.abs(deersim.vehicles[vehicle].lane - deer.lane) === 1)) {
 
-         // Generate a random decimal, which determines whether a voice will play.
          var voiceTrigger = Math.random();
 
-         // Generate a random decimal, which determines which voice if any plays.
          var voiceSelector = Math.random();
 
-         if (voiceTrigger < 0.1) // If the voice trigger is sufficiently low...
-            // ...then play a voice.
+         if (voiceTrigger < 0.1)
             playVoice(deersim.vehicles[vehicle], voiceSelector);
       }
    }

--- a/deersim/powerups.js
+++ b/deersim/powerups.js
@@ -12,18 +12,16 @@
  | @param int lane -- the lane in which to generate this Irradiation. |
 \*--------------------------------------------------------------------*/
 function Irradiation(lane) {
-   this.d     = 128;         // Assign this Irradiation's dimension.
-   this.lane  = lane;        // Assign this Irradiation's lane.
-   this.speed = 3;           // Assign this Irradiation a default speed of 3.
-   this.collisionWidth = 89; // Assign this Irradiation's collision width.
+   this.d     = 128;
+   this.lane  = lane;
+   this.speed = 3;
+   this.collisionWidth = 89;
 
-   // Assign this Irradiation's x position as adjacent to the canvas boundary.
    this.x = deersim.canvas.width - this.d;
 
-   // Assign this Irradiation's y position based on its lane.
    this.y = (CONST_LANE_0_BASE - 15) - (CONST_LANE_HEIGHT * (this.lane + 1));
-   
-   this.index = 0; // Assign position in the game's sound effects array for "VoxCometSoundCheck".
+
+   this.index = 0;
 }
 
 /*----------------------------------------------------------------------*\
@@ -32,18 +30,16 @@ function Irradiation(lane) {
  | @param int lane -- the lane in which to generate this LightningRobe. |
 \*----------------------------------------------------------------------*/
 function LightningRobe(lane) {
-   this.d     = 64;          // Assign this LightningRobe's dimension.
-   this.lane  = lane;        // Assign this LightningRobe's lane.
-   this.speed = 3;           // Assign this LightningRobe a default speed of 3.
-   this.collisionWidth = 42; // Assign this LightningRobe's collision width.
+   this.d     = 64;
+   this.lane  = lane;
+   this.speed = 3;
+   this.collisionWidth = 42;
 
-   // Assign this LightningRobe's x position as adjacent to the canvas boundary.
    this.x = deersim.canvas.width - this.d;
 
-   // Assign this LightningRobe's y position based on its lane.
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane);
-   
-   this.index = 1; // Assign position in the game's sound effects array for "DruidChant".
+
+   this.index = 1;
 }
 
 // ---- End of object declarations. ----
@@ -54,7 +50,6 @@ function LightningRobe(lane) {
  | Draws this Irradiation. |
 \*-------------------------*/
 Irradiation.prototype.draw = function() {
-   // Draw some barrels and toxic waste.
    deersim.canvasContext.drawImage(document.getElementById("Irradiation"), this.x, this.y);
 }
 
@@ -62,14 +57,13 @@ Irradiation.prototype.draw = function() {
  | Updates this Irradiation. |
 \*---------------------------*/
 Irradiation.prototype.update = function() {
-   this.x -= this.speed; // Move this Irradiation to the left, proportional to its speed.
+   this.x -= this.speed;
 }
 
 /*-----------------------------------------------------------*\
  | Draws this LightningRobe. For now, just draw a deer icon. |
 \*-----------------------------------------------------------*/
 LightningRobe.prototype.draw = function() {
-   // Draw a deer icon.
    deersim.canvasContext.drawImage(document.getElementById("LightningDeerTest"), this.x, this.y);
 }
 
@@ -77,7 +71,7 @@ LightningRobe.prototype.draw = function() {
  | Updates this LightningRobe. |
 \*-----------------------------*/
 LightningRobe.prototype.update = function() {
-   this.x -= this.speed; // Move this LightningRobe to the left, proportional to its speed.
+   this.x -= this.speed;
 }
 
 // ---- End of function declarations. ----

--- a/deersim/profile.js
+++ b/deersim/profile.js
@@ -6,53 +6,45 @@
 \*------------------------------------------------------------------------------------*/
 
 function Profile() {
-   this.level            = 1;  // Assign this Profile's current level, in terms of experience.
-   this.previousLevel    = 0;  // Assign this Profile's previous level, in terms of experience.
-   this.remainingDeer    = 4;  // Assign this Profile's number of remaining deer.
-   this.consecutiveLvls  = 0;  // Stores number of levels grown within current environment.
+   this.level            = 1;
+   this.previousLevel    = 0;
+   this.remainingDeer    = 4;
+   this.consecutiveLvls  = 0;
    // #TODO -- implement resets of consecutiveLvls when the player enters new environments.
-   this.counter          = 80; // Assign this Profile's counter, for gating level growth.
-   this.currentLevelGate = 0;  // Assign the current level's experience gate.
-   this.nextLevelGate    = 80; // Assign the experience gate for level 2.
-   this.damage           = 0;  // Assign this Profile's amount of property damage.
-   this.xp               = 0;  // Assign this Profile's experience.
+   this.counter          = 80;
+   this.currentLevelGate = 0;
+   this.nextLevelGate    = 80;
+   this.damage           = 0;
+   this.xp               = 0;
 
    // #TODO -- add this to the objects array
-   this.levelBar = new Bar(383, 699); // Create this Profile's level bar.
+   this.levelBar = new Bar(383, 699);
 
-   // Create this Profile's NumberBlockString to display property damage to the player.
    this.numberBlockString = new NumberBlockString();
 
-   /* Create a balloon and image owned by this Profile which will occasionally
-      be used to display the map of the current level to the player.           */
    this.mapBalloon = new StaticMenuObject(
       50,                    // x
       50,                    // y
       "SpeechBalloon246x234" // imageHandle
       );
-   
+
    this.connecticutMap = new StaticMenuObject(
       50,              // x
       50,              // y
       "ConnecticutMap" // imageHandle
       );
 
-   /* Create a cursor to display the active deer herd's
-      current location, set by default to exit 1 in I-84. */
    this.locationMarker = new Cursor(
       this.mapBalloon.x + 30,  // x
       this.mapBalloon.y + 115, // y
       );
 
-   /* Create an ExitSign to display the player's
-      current Exit. By default, this is exit 1 in I-84. */
    this.exitSign = new ExitSign(
       800,                      // x, hand-chosen value
       CONST_CANVAS_HEIGHT - 48, // y, hand-chosen value
       "ExitSign01"              // imageHandle
       );
 
-   // Create an array of DeerHeads to display the number of remaining deer.
    this.createRemainingDeerHeads();
 }; // Profile()
 
@@ -62,15 +54,13 @@ function Profile() {
  | in order to return unique values for unique vehicles.           |
 \*-----------------------------------------------------------------*/
 Profile.prototype.changeDamage = function(baseValue) {
-   var randomDecimal = Math.random(); // Generate a random decimal.
+   var randomDecimal = Math.random();
 
-   // Calculate a modified value, based on the base value and the random decimal.
    var modValue = baseValue + ((randomDecimal - 0.5) * (baseValue / 10));
 
-   // Change this Profile's damage by the modified value, rounded down.
    this.damage += Math.floor(modValue);
 
-   return modValue; // Modified value can be used outside this function.
+   return modValue;
 };
 
 /*----------------------------------------------------------------------------------*\
@@ -79,13 +69,11 @@ Profile.prototype.changeDamage = function(baseValue) {
  | @param int change -- the amount by which to change the Profile's remaining Deer. |
 \*----------------------------------------------------------------------------------*/
 Profile.prototype.changeRemainingDeer = function(change) {
-   this.remainingDeer += change; // Modify the count of remaining deer.
+   this.remainingDeer += change;
 
-   // Prevent the player from owning more than the maximum allowed remaining Deer.
    if (this.remainingDeer > CONST_MAX_REMAINING_DEER)
       this.remainingDeer = CONST_MAX_REMAINING_DEER;
 
-   // Prevent the player from owning fewer than zero remaining Deer.
    if (this.remainingDeer < 0)
       this.remainingDeer = 0;
 };
@@ -94,22 +82,15 @@ Profile.prototype.changeRemainingDeer = function(change) {
  | Create an array of DeerHeads to display the number of remaining deer. |
 \*-----------------------------------------------------------------------*/
 Profile.prototype.createRemainingDeerHeads = function() {
-   // Prevent the player from owning more than the maximum allowed remaining Deer.
    if (this.remainingDeer > CONST_MAX_REMAINING_DEER)
       this.remainingDeer = CONST_MAX_REMAINING_DEER;
 
-   // Prevent the player from owning fewer than zero remaining Deer.
    if (this.remainingDeer < 0)
       this.remainingDeer = 0;
 
-   // Initialize an array for this Profile to display
-   // the number of remaining deer to the player.
    this.remainingDeerHeads = new Array(CONST_MAX_REMAINING_DEER);
 
-   // For every one of this Profile's remaining deer,
    for (var i = 0; i < CONST_MAX_REMAINING_DEER; i++) {
-      // Create a new DeerHead object to represent the remaining deer.
-      // Separate rows are defined for DeerHeads #1-10, and #11-20.
       if (i < 10) // Bottom row
          this.remainingDeerHeads[i] = new DeerHead((i * CONST_MAX_REMAINING_DEER) + 10,
                                                    CONST_CANVAS_HEIGHT - 34);
@@ -125,17 +106,15 @@ Profile.prototype.createRemainingDeerHeads = function() {
  | to the player about their progress in the game.            |
 \*------------------------------------------------------------*/
 Profile.prototype.draw = function() {
-   // For every DeerHead owned by this Profile,
    for (var i = 0; i < this.remainingDeer; i++) {
-      this.remainingDeerHeads[i].draw(); // Draw the DeerHead.
+      this.remainingDeerHeads[i].draw();
    }
 
-   this.xpString.draw();          // Draw the player profile's experience string onscreen.
-   this.levelBar.draw();          // Draw the player profile's level bar onscreen.
-   this.numberBlockString.draw(); // Draw the player profile's property damage onscreen.
-   this.exitSign.draw();          // Draw the player profile's ExitSign onscreen.
+   this.xpString.draw();
+   this.levelBar.draw();
+   this.numberBlockString.draw();
+   this.exitSign.draw();
 
-   // If the game is paused, display the map and location cursor to the player.
    if (deersim.state === "pause") {
       this.mapBalloon.draw();
       this.connecticutMap.draw();
@@ -152,26 +131,26 @@ Profile.prototype.draw = function() {
  | 0.1 as in deersim classic.                                          |
 \*---------------------------------------------------------------------*/
 Profile.prototype.getInput = function() {
-   if (deer.state === "active") { // Monitor input during a round of play.
-      var numKeysPressed = 0; // Stores the number of keys pressed during this frame.
+   if (deer.state === "active") {
+      var numKeysPressed = 0;
 
-      for (var key in keysDown) { // Iterate through each key currently pressed.
-         var value = Number(key); // Assign numeric wrapper of key to variable 'value'.
+      for (var key in keysDown) {
+         var value = Number(key);
 
          switch (value) {
             case 37: // Key pressed is left arrow key.
-               this.xp += 0.09; // Add slightly less experience.
+               this.xp += 0.09;
                numKeysPressed++;
                break;
             case 39: // Key pressed is right arrow key.
-               this.xp += 0.12; // Add slightly more experience.
+               this.xp += 0.12;
                numKeysPressed++;
                break;
          }
       }
 
-      if (numKeysPressed === 0) { // If no keys are currently pressed...
-         this.xp += 0.1; // ...then the player profile gains 0.1 experience.
+      if (numKeysPressed === 0) {
+         this.xp += 0.1;
       }
    }
 };
@@ -181,7 +160,6 @@ Profile.prototype.getInput = function() {
  | @returns TextString[] textStrings -- this Profile's level and experience TextStrings. |
 \*---------------------------------------------------------------------------------------*/
 Profile.prototype.initTextStrings = function() {
-   // Initialize a TextString to display this Profile's experience.
    this.xpString = new TextString(220, 686, CONST_FONT_SIZE_SMALL, "default", "XP:  ", "Small");
 };
 
@@ -190,15 +168,13 @@ Profile.prototype.initTextStrings = function() {
  | experience gate, and calculates new member variables if so. |
 \*-------------------------------------------------------------*/
 Profile.prototype.setLevel = function() {
-   // If this Profile's experience has exceeded the next level's gate...
    if (this.xp >= this.nextLevelGate) {
-      this.level++;                               // ...then increment its level...
-      this.consecutiveLvls++;                     // ...increase consecutive levels...
-      this.counter += 10;                         // ...slightly increase its counter...
-      this.currentLevelGate = this.nextLevelGate; // ...relay next to current level gate...
-      this.nextLevelGate += this.counter;         // ...and jump to next gate, based on counter.
+      this.level++;
+      this.consecutiveLvls++;
+      this.counter += 10;
+      this.currentLevelGate = this.nextLevelGate;
+      this.nextLevelGate += this.counter;
 
-      // Modify this Profile's cursor location based on its level.
       switch (this.level) {
          case 0:  this.locationMarker.x = 80;  this.locationMarker.y = 165; break; // EXIT 1
          case 1:  this.locationMarker.x = 84;  this.locationMarker.y = 166; break; // EXIT 2
@@ -269,7 +245,7 @@ Profile.prototype.setLevel = function() {
          case 66: this.locationMarker.x = 199; this.locationMarker.y = 104; break; // EXIT 67
          case 67: this.locationMarker.x = 203; this.locationMarker.y = 101; break; // EXIT 68
          case 68: this.locationMarker.x = 207; this.locationMarker.y = 98;  break; // EXIT 69
-         case 69: this.locationMarker.x = 210; this.locationMarker.y = 95;  break; // EXIT 70 
+         case 69: this.locationMarker.x = 210; this.locationMarker.y = 95;  break; // EXIT 70
          case 70: this.locationMarker.x = 213; this.locationMarker.y = 92;  break; // EXIT 71
          case 71: this.locationMarker.x = 217; this.locationMarker.y = 90;  break; // EXIT 72
          case 72: this.locationMarker.x = 218; this.locationMarker.y = 88;  break; // EXIT 73
@@ -282,14 +258,12 @@ Profile.prototype.setLevel = function() {
  | Updates this Profile. |
 \*-----------------------*/
 Profile.prototype.update = function() {
-   this.setLevel();          // Set this Profile's level.
-   this.updateTextStrings(); // Update this Profile's TextStrings.
-   this.updateLevelBar();    // Update this Profile's level bar.
+   this.setLevel();
+   this.updateTextStrings();
+   this.updateLevelBar();
 
-   // Update this Profile's NumberBlockString's property damage value.
    this.numberBlockString.updatePropertyDamage(this.damage);
 
-   // Update this Profile's ExitSign.
    this.exitSign.update(
       this.level
       );
@@ -299,7 +273,6 @@ Profile.prototype.update = function() {
  | Updates this Profile's level bar. |
 \*-----------------------------------*/
 Profile.prototype.updateLevelBar = function() {
-   // Update this Profile's level bar using this Profile's member variables.
    this.levelBar.updateFrontWidth(this.xp, this.currentLevelGate, this.nextLevelGate);
 };
 
@@ -307,6 +280,5 @@ Profile.prototype.updateLevelBar = function() {
  | Updates the level and experience TextStrings owned by this Profile. |
 \*---------------------------------------------------------------------*/
 Profile.prototype.updateTextStrings = function() {
-   // Update this Profile's experience TextString.
    this.xpString.updateWithStringOverwrite("XP:  " + Math.floor(this.xp));
 };

--- a/deersim/projectiles.js
+++ b/deersim/projectiles.js
@@ -14,16 +14,12 @@
  | @param int lane -- the lane of the road this LightningBolt should occupy.     |
 \*-------------------------------------------------------------------------------*/
 function LightningBolt(x, lane) {
-   this.x = x; // Assign this LightningBolt's x position.
-   
-   /* Assign this LightningBolt's y position based on its lane. |
-   |  Subtract an extra 64 pixels due to the increased          |
-   |  size of the LightningBolt (128x128 as opposed to 64x64).  */
+   this.x = x;
+
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * lane) - 64;
-   
-   this.lane = lane; // Assign this LightningBolt's lane.
-   
-   // Create an animation which will be used to display this LightningBolt.
+
+   this.lane = lane;
+
    this.animation = new AnimationBlock(this.x, this.y, 128, 3, "LightningBolt");
 };
 
@@ -35,25 +31,22 @@ function LightningBolt(x, lane) {
  | Draws this LightningBolt. |
 \*---------------------------*/
 LightningBolt.prototype.draw = function() {
-   this.animation.draw(); // Draw this LightningBolt's AnimationBlock.
+   this.animation.draw();
 };
 
 /*-----------------------------*\
  | Updates this LightningBolt. |
 \*-----------------------------*/
 LightningBolt.prototype.update = function() {
-   // Update this LightningBolt's x position, based on the active deer's x position.
    // this.x = deer.x + CONST_DEER_WIDTH;
    this.animation.x = deer.x + CONST_DEER_WIDTH;
-   
-   // Update this LightningBolt's y position, based on the active deer's y position.
+
    // this.y = deer.y + 35;
    this.animation.y = deer.y + 35 - 64;
-   
-   // Update this LightningBolt's lane, based on the active deer's lane.
+
    this.lane = deer.lane;
-   
-   this.animation.update(); // Update this LightningBolt's AnimationBlock.
+
+   this.animation.update();
 };
 
 // ---- End of function declarations. ----

--- a/deersim/splicingFunctions.js
+++ b/deersim/splicingFunctions.js
@@ -12,16 +12,16 @@
  | in level) calls for a complete scrub of in-play objects.  |
 \*-----------------------------------------------------------*/
 var clearAllPreviousGameObjects = function() {
-   while (deersim.gameObjects.length > 0) // While there are objects remaining in the array...
-      deersim.gameObjects.splice(0, 1);   // ...remove them, one by one.
-   while (deersim.vehicles.length > 0)    // While there are vehicles remaining in the array...
-      deersim.vehicles.splice(0, 1);      // ...remove them, one by one.
-   while (deersim.obstacles.length > 0)   // While there are obstacles remaining in the array...
-      deersim.obstacles.splice(0, 1);     // ...remove them, one by one.
-   while (deersim.powerups.length > 0)    // While there are powerups remaining in the array...
-      deersim.powerups.splice(0, 1);      // ...remove them, one by one.
-   while (deersim.projectiles.length > 0) // While there are projectiles remaining in the array...
-      deersim.projectiles.splice(0, 1);   // ...remove them, one by one.
+   while (deersim.gameObjects.length > 0)
+      deersim.gameObjects.splice(0, 1);
+   while (deersim.vehicles.length > 0)
+      deersim.vehicles.splice(0, 1);
+   while (deersim.obstacles.length > 0)
+      deersim.obstacles.splice(0, 1);
+   while (deersim.powerups.length > 0)
+      deersim.powerups.splice(0, 1);
+   while (deersim.projectiles.length > 0)
+      deersim.projectiles.splice(0, 1);
 };
 
 /*------------------------------------------------------------------------------*\
@@ -30,53 +30,47 @@ var clearAllPreviousGameObjects = function() {
  | expire, there is an if statement coded into the while loop in this function. |
 \*------------------------------------------------------------------------------*/
 var clearExpiredGameObjects = function() {
-   var index = 0; // Used to iterate through game objects array.
+   var index = 0;
 
    while (index < deersim.gameObjects.length) {
-      // Powerup Bars expire (and disappear) when the active Deer's use of the powerup is disabled.
       if (deersim.gameObjects[index] instanceof Bar) {
          if (deersim.gameObjects[index].done === CONST_TRUE) {
             deersim.gameObjects.splice(index, 1);
          }
          else
-            index++; // If the Bar isn't expired, keep iterating...
+            index++;
       }
-      // ExpiringObjects and ExpiringCursors are objects that are programmed to expire.
       else if ((deersim.gameObjects[index] instanceof ExpiringCursor)
            || (deersim.gameObjects[index] instanceof ExpiringObject)) {
-         // Check to see if the object has expired.
          if (deersim.gameObjects[index].remainingFrames <= 0) {
             deersim.gameObjects.splice(index, 1);
          }
          else
-            index++; // If the expiring object hasn't expired, keep iterating...
+            index++;
       }
-      // Starbursts expire (and disappear) after they finish ascending briefly.
       else if (deersim.gameObjects[index] instanceof Starburst) {
          if (deersim.gameObjects[index].done === CONST_TRUE) {
-            var powerupBar = new Bar( // Create a new bar to display powerup depletion.
+            var powerupBar = new Bar(
                deersim.gameObjects[index].x - 10,                   // x
                deersim.gameObjects[index].y + CONST_DIM_LARGE - 16  // y
                );
 
-            // Assign the new Bar a function (i.e. it's a Powerup Bar in this case).
             powerupBar.function = deersim.gameObjects[index].purpose;
             deersim.gameObjects.push(powerupBar);
 
             deersim.gameObjects.splice(index, 1);
          }
          else
-            index++; // If the ExpiringObject isn't expired, keep iterating...
+            index++;
       }
-      // TextStrings listing dollar values on Vehicle death expire after ascending briefly.
       else if (deersim.gameObjects[index] instanceof TextString) {
          if (deersim.gameObjects[index].isDone())
             deersim.gameObjects.splice(index, 1);
          else
-            index++; // If the TextString isn't expired, keep iterating...
+            index++;
       }
       else
-         index++; // If the object isn't a type that expires, keep iterating...
+         index++;
    }
 }; // clearExpiredGameObjects()
 
@@ -85,45 +79,43 @@ var clearExpiredGameObjects = function() {
  | all AnimationBlocks whose animations have finished.  |
 \*------------------------------------------------------*/
 var clearFinishedAnimations = function() {
-   var i = 0; // Iterator.
+   var i = 0;
 
-   while (i < deersim.gameObjects.length) { // Considering each game object,
-      if (deersim.gameObjects[i] instanceof AnimationBlock) { // If the object is an AnimationBlock...
-         // ...and the AnimationBlock's animation is over...
+   while (i < deersim.gameObjects.length) {
+      if (deersim.gameObjects[i] instanceof AnimationBlock) {
          if (deersim.gameObjects[i].frameCounter >= (7 * deersim.gameObjects[i].length)) {
-            deersim.gameObjects.splice(i, 1); // ...then remove the AnimationBlock from the objects array.
+            deersim.gameObjects.splice(i, 1);
          }
          else {
-            i++; // Otherwise, increment.
+            i++;
          }
       }
-      else if (deersim.gameObjects[i] instanceof Exclamation) { // If the object is an Exclamation...
-         if (deersim.gameObjects[i].frameCounter >= 15 * 12) { // ...and the Exclamation is over...
-            deersim.gameObjects.splice(i, 1); // ...then remove the Exclamation from the objects array.
+      else if (deersim.gameObjects[i] instanceof Exclamation) {
+         if (deersim.gameObjects[i].frameCounter >= 15 * 12) {
+            deersim.gameObjects.splice(i, 1);
          }
          else {
-            i++; // Otherwise, increment.
+            i++;
          }
       }
       else {
-         i++; // Otherwise, increment.
+         i++;
       }
    }
-   
-   i = 0; // Reset the iterator for the upcoming loop.
-   
-   while (i < deersim.projectiles.length) { // Considering each projectile,
-      if (deersim.projectiles[i] instanceof LightningBolt) { // If the object is a LightningBolt...
-         // ...and the LightningBolt's animation is over...
+
+   i = 0;
+
+   while (i < deersim.projectiles.length) {
+      if (deersim.projectiles[i] instanceof LightningBolt) {
          if (deersim.projectiles[i].animation.frameCounter >= (7 * deersim.projectiles[i].animation.length)) {
-            deersim.projectiles.splice(i, 1); // ...then remove the LightningBolt from the projectiles array.
+            deersim.projectiles.splice(i, 1);
          }
          else {
-            i++; // Otherwise, increment.
+            i++;
          }
       }
       else {
-         i++; // Otherwise, increment.
+         i++;
       }
    }
 };
@@ -132,14 +124,14 @@ var clearFinishedAnimations = function() {
  | Scans through the array of game objects and removes all menu objects. |
 \*-----------------------------------------------------------------------*/
 function clearMenuObjects(a_deersim) {
-   var i = 0; // Iterator.
+   var i = 0;
 
-   while (i < a_deersim.gameObjects.length) {                // Considering each game object,
+   while (i < a_deersim.gameObjects.length) {
       /* if ((gameObjects[i] instanceof DialogBox)           // If the object is a DialogBox,
        || (gameObjects[i] instanceof StaticMenuObject) */
       if ((a_deersim.gameObjects[i] instanceof StaticMenuObject)
-       || (a_deersim.gameObjects[i] instanceof Cursor)) { // Or a StaticMenuObject,
-         a_deersim.gameObjects.splice(i, 1); // Remove the object from the object array.
+       || (a_deersim.gameObjects[i] instanceof Cursor)) {
+         a_deersim.gameObjects.splice(i, 1);
       }
       else {
          i++;
@@ -153,38 +145,30 @@ function clearMenuObjects(a_deersim) {
 // #TODO -- expand the right boundary this function checks for so that I can create
 // vehicles offscreen to the right instead of within screen bounds.
 var clearPassedObjects = function() {
-   // Iterate through each object currently in play.
    for (var gameObject in deersim.gameObjects) {
-      // Remove objects which have been killed, and would otherwise fall indefinitely.
       if (deersim.gameObjects[gameObject].y > (CONST_CANVAS_HEIGHT * 2)) {
          deersim.gameObjects.splice(gameObject, 1);
       }
    }
 
-   // Iterate through each obstacle currently in play.
    for (var obstacle in deersim.obstacles) {
-      // If an obstacle in play has exited the screen,
       if ((deersim.obstacles[obstacle].x < -200)
        || (deersim.obstacles[obstacle].x > CONST_CANVAS_WIDTH + 200)) {
-         deersim.obstacles.splice(obstacle, 1); // Then remove that obstacle from play.
+         deersim.obstacles.splice(obstacle, 1);
       }
    }
 
-   // Iterate through each powerup currently in play.
    for (var powerup in deersim.powerups) {
-      // If a powerup in play has exited the screen,
       if ((deersim.powerups[powerup].x < -200)
        || (deersim.powerups[powerup].x > CONST_CANVAS_WIDTH + 200)) {
-         deersim.powerups.splice(powerup, 1); // Then remove that powerup from play.
+         deersim.powerups.splice(powerup, 1);
       }
    }
 
-   // Iterate through each vehicle currently in play.
    for (var vehicle in deersim.vehicles) {
-      // If a vehicle in play has exited the screen,
       if ((deersim.vehicles[vehicle].x < -200)
        || (deersim.vehicles[vehicle].x > CONST_CANVAS_WIDTH + 100)) {
-         deersim.vehicles.splice(vehicle, 1); // Then remove that vehicle from play.
+         deersim.vehicles.splice(vehicle, 1);
       }
    }
 };
@@ -194,20 +178,20 @@ var clearPassedObjects = function() {
  | to remove active Bars from play when the active deer is killed.    |
 \*--------------------------------------------------------------------*/
 var clearPowerupBars = function() {
-   var i = 0; // Iterator.
+   var i = 0;
 
-   while (i < deersim.gameObjects.length) { // Check all active game objects.
-      if (deersim.gameObjects[i] instanceof Bar) { // If the object is a Bar...
+   while (i < deersim.gameObjects.length) {
+      if (deersim.gameObjects[i] instanceof Bar) {
          if ((deersim.gameObjects[i].function === "irradiated")
           || (deersim.gameObjects[i].function === "enlightened")) {
-            deersim.gameObjects.splice(i, 1); // ...then remove the object from the objects array.
+            deersim.gameObjects.splice(i, 1);
          }
          else {
-            i++; // ...otherwise, increment.
+            i++;
          }
       }
       else {
-         i++; // ...otherwise, increment.
+         i++;
       }
    }
 }; // clearPowerupBars
@@ -216,11 +200,11 @@ var clearPowerupBars = function() {
  | Scans through the array of game objects and removes all TextStrings. |
 \*----------------------------------------------------------------------*/
 function clearTextStrings(a_deersim) {
-   var i = 0; // Iterator.
+   var i = 0;
 
-   while (i < a_deersim.gameObjects.length) {               // Considering each game object,
-      if (a_deersim.gameObjects[i] instanceof TextString) { // If the object is a TextString,
-         a_deersim.gameObjects.splice(i, 1);                // Remove the object from the object array.
+   while (i < a_deersim.gameObjects.length) {
+      if (a_deersim.gameObjects[i] instanceof TextString) {
+         a_deersim.gameObjects.splice(i, 1);
       }
       else {
          i++;

--- a/deersim/transitions.js
+++ b/deersim/transitions.js
@@ -10,22 +10,19 @@
  | Executes when the game transitions into the 'pause' state. |
 \*------------------------------------------------------------*/
 var pause = function() {
-   pauseStateBuffer = deersim.state; // Record the game's previous state.
+   pauseStateBuffer = deersim.state;
 
    // #TODO -- figure out how to implement the key timer here.
-   deersim.state = "pause";  // Transition the game to the pause state.
-   deersim.pauseTimer++;     // Start the pause timer.
+   deersim.state = "pause";
+   deersim.pauseTimer++;
 
-   // Initialize the pause menu's dialog box.
    var pauseBox = new StaticMenuObject((CONST_CANVAS_WIDTH / 2) - 320,
                             -635, "SpeechBalloon640x75");
 
-   // Initialize the TextString, "PAUSED".
    var paused = new TextString(((CONST_CANVAS_WIDTH / 2)
                          - (CONST_FONT_SIZE_LARGE * 3)),
                            320, CONST_FONT_SIZE_LARGE, "default", "PAUSED", "Large");
 
-   // Initialize a message to display during the pause menu.
    var pauseMessage = new TextString(((CONST_CANVAS_WIDTH / 2) - 310),
                                  ((CONST_CANVAS_HEIGHT / 2) - 10),
                                  CONST_FONT_SIZE_SMALL,
@@ -33,7 +30,6 @@ var pause = function() {
                                  "PRESS ESC TO CONTINUE SLAUGHTERING DEER",
                                  "Small");
 
-   // Add the newly created objects to the objects array.
    deersim.gameObjects.push(pauseBox);
    deersim.gameObjects.push(paused);
    deersim.gameObjects.push(pauseMessage);
@@ -41,15 +37,15 @@ var pause = function() {
    deersim.backgroundManager.bgIsScrolling = CONST_FALSE;
    deersim.musicManager.createAndDisplayMusicTicker(deersim);
 
-   for (var soundEffect in deersim.soundEffects) {       // For each of the game's sound effects...
-      if (!(deersim.soundEffects[soundEffect].paused)) { // If the sound effect is playing...
-         deersim.soundEffects[soundEffect].pause();      // Pause it.
+   for (var soundEffect in deersim.soundEffects) {
+      if (!(deersim.soundEffects[soundEffect].paused)) {
+         deersim.soundEffects[soundEffect].pause();
       }
    }
 
-   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_HIGH].pause();         // Pause in case already playing.
-   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_HIGH].currentTime = 0; // Re-seek to t0.
-   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_HIGH].play();          // MenuSelection
+   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_HIGH].pause();
+   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_HIGH].currentTime = 0;
+   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_HIGH].play();
 }; // pause
 
 /*----------------------------------------------------------------------*\
@@ -58,46 +54,34 @@ var pause = function() {
  | which are generated to warn the player of the upcoming boss battle.  |
 \*----------------------------------------------------------------------*/
 var preparePlayerForCoopsEntry = function() {
-   // For simplicity, use variables to isolate the game's current background music.
    var backgroundTrack = deersim.musicManager.backgroundTrack;
 
-   // Trigger the creation of new Exclamation objects during narrow time windows.
    if ((backgroundTrack.currentTime > 4.67)
     && (backgroundTrack.currentTime < 4.77)) {
-      // Default to triggering the creation of a new Exclamation.
       var shouldCreateNewExclamation = CONST_TRUE;
 
-      // Search the game objects array, and if we find another Exclamation...
       for (var gameObject in deersim.gameObjects) {
          if (deersim.gameObjects[gameObject] instanceof Exclamation) {
-            // ...then decide not to create a new one.
             shouldCreateNewExclamation = CONST_FALSE;
          }
       }
 
-      // If it is decided to create a new Exclamation...
       if (shouldCreateNewExclamation === CONST_TRUE) {
-         // ...then create it, push it into the objects array, and play its sound effect.
          deersim.gameObjects.push(new Exclamation(1));
          pauseAndReplaySoundEffect(CONST_SOUND_INDEX_EXCLAMATION_REVERB_X4);
       }
    }
    else if ((backgroundTrack.currentTime > 9.33)
          && (backgroundTrack.currentTime < 9.43)) {
-      // Default to triggering the creation of a new Exclamation.
       var shouldCreateNewExclamation = CONST_TRUE;
 
-      // Search the game objects array, and if we find another Exclamation...
       for (var gameObject in deersim.gameObjects) {
          if (deersim.gameObjects[gameObject] instanceof Exclamation) {
-            // ...then decide not to create a new one.
             shouldCreateNewExclamation = CONST_FALSE;
          }
       }
 
-      // If it is decided to create a new Exclamation...
       if (shouldCreateNewExclamation === CONST_TRUE) {
-         // ...then create it, push it into the objects array, and play its sound effect.
          deersim.gameObjects.push(new Exclamation(2));
          pauseAndReplaySoundEffect(CONST_SOUND_INDEX_EXCLAMATION_REVERB_X8);
       }
@@ -110,26 +94,24 @@ var preparePlayerForCoopsEntry = function() {
 \*----------------------------------------------------------------------*/
 var startBossBattle = function() {
    if (deersim.backgroundManager.environment === CONST_ENVIRONMENT_I84) {
-      deersim.state = "bossBattle"; // Set the game state to boss battle.
+      deersim.state = "bossBattle";
 
-      // Create a new Exclamation to alert the player that the boss battle has begun.
       var exclamation = new Exclamation(0);
 
-      deersim.gameObjects.push(exclamation); // Add the Exclamation to the objects array.
+      deersim.gameObjects.push(exclamation);
 
-      deersim.soundEffects[CONST_SOUND_INDEX_EXCLAMATION].play(); // Play the Exclamation's sound effect.
+      deersim.soundEffects[CONST_SOUND_INDEX_EXCLAMATION].play();
 
-      boss = deersim.generator.generateBoss(); // Generate a new boss for the player to fight.
-      deersim.gameObjects.push(boss);          // Add the new boss to the game objects array.
-      boss.target = deer;                      // Set the active deer as the new boss's target.
-      
-      // loadMusic("Schizoid8Bit"); // Load the Coop boss battle theme music.
-      loadMusic( // Load the Coop boss battle theme music.
+      boss = deersim.generator.generateBoss();
+      deersim.gameObjects.push(boss);
+      boss.target = deer;
+
+      // loadMusic("Schizoid8Bit");
+      loadMusic(
          "Schizoid8Bit",         // bgTrack
          "NO COPYRIGHT INTENDED" // bgTrackID
          );
 
-      // Set the newly loaded background music to loop.
       deersim.musicManager.backgroundTrack.loop = CONST_TRUE;
    }
 }; // startBossBattle()
@@ -138,35 +120,27 @@ var startBossBattle = function() {
  | Initializes the game over menu, and triggers when the player runs out of Deer. |
 \*--------------------------------------------------------------------------------*/
 var startGameOverMenu = function() {
-   // If we transition from a boss battle to the game over menu...
    if (deersim.state === "bossBattle")
-      // ...then flag the MusicManager to load new music on next main menu.
       deersim.musicManager.reloadOnNextMain = CONST_TRUE;
 
-   /* If the RoadManager is generating road on the bottom lane, then switch
-      the bottom lane off and modify the RoadManager's configuration accordingly. */
    if (deersim.roadManager.generateFlags[0] === CONST_TRUE) {
       deersim.roadManager.closeBottomLaneRequested = CONST_TRUE;
       deersim.roadManager.minLane                  = 2;
       deersim.roadManager.sideHeightBottom         = deersim.roadManager.kBottomHeightMid;
    }
 
-   /* If the RoadManager is generating road on the top lane, then switch
-      the top lane off and modify the RoadManager's configuration accordingly. */
    if (deersim.roadManager.generateFlags[4] === CONST_TRUE) {
       deersim.roadManager.closeTopLaneRequested = CONST_TRUE;
       deersim.roadManager.maxLane               = 4;
       deersim.roadManager.sideHeightTop         = deersim.roadManager.kTopHeightMid;
    }
 
-   deersim.state = "gameOver"; // Transition the game to the gameOver state.
+   deersim.state = "gameOver";
 
-   // Create a speech balloon to store the text, "GAME OVER".
    var goSpeechBalloon = new StaticMenuObject((CONST_CANVAS_WIDTH / 2) - 250,
                                        -285,
                                        "SpeechBalloon500x60");
 
-   // Create a TextString used to store the text, "GAME OVER".
    var gameOver = new TextString((CONST_CANVAS_WIDTH / 2) - 144,
                                  180,
                                  CONST_FONT_SIZE_LARGE,
@@ -174,18 +148,14 @@ var startGameOverMenu = function() {
                                  "GAME OVER",
                                  "Large");
 
-   // Create a dialog box to store the game over message.
    var gomSpeechBalloon = new StaticMenuObject((CONST_CANVAS_WIDTH / 2) - 344,
                                      -665,
                                      "SpeechBalloon688x129");
 
-   // Create an instance of Yorig, Deer Scientist of Athens.
    var yorig = new StaticMenuObject(65, -50, "Yorig512");
 
-   // Create an array of TextStrings to display to the player.
    var lines = deersim.messageGenerator.gameOverMessage();
 
-   // Add newly created objects to object array.
    deersim.gameObjects.push(goSpeechBalloon);
    deersim.gameObjects.push(gomSpeechBalloon);
    deersim.gameObjects.push(yorig);
@@ -200,30 +170,26 @@ var startGameOverMenu = function() {
  | Initializes the 'main' state and draws the main menu. |
 \*-------------------------------------------------------*/
 function startMainMenu(a_deersim) {
-   a_deersim.state = "main"; // Transition the game to the main state.
+   a_deersim.state = "main";
 
-   clearTextStrings(a_deersim); // Clear existing TextString objects from the objects array.
-   clearMenuObjects(a_deersim); // Clear existing menu objects from the objects array.
+   clearTextStrings(a_deersim);
+   clearMenuObjects(a_deersim);
 
-   // Initialize the main menu's dialog box.
    var mainMenuBox = new StaticMenuObject(((CONST_CANVAS_WIDTH / 2) + 85),
                                -92, "SpeechBalloon385x97");
 
-   // Initialize the game title's dialog box.
    var titleBox = new StaticMenuObject(
       (CONST_CANVAS_WIDTH / 2) - 215,  // x
       (CONST_CANVAS_HEIGHT / 2) - 114, // y
       "SpeechBalloon430x61"            // imageHandle
       );
 
-   // Initialize the I-84 emblem.
    var interstateEmblem = new StaticMenuObject(
       (CONST_CANVAS_WIDTH / 2) - 196,  // x
       (CONST_CANVAS_HEIGHT / 2) - 130, // y
       "InterstateEmblem"               // imageHandle
       );
 
-   // Initialize the text, "SIMULATOR".
    var simulator = new TextString(
       (CONST_CANVAS_WIDTH / 2) - 80,   // x
       (CONST_CANVAS_HEIGHT / 2) - 100, // y
@@ -233,57 +199,47 @@ function startMainMenu(a_deersim) {
       "Large"                          // size
       );
 
-   // Initialize the main menu cursor.
    a_deersim.mainMenuCursor = new Cursor((CONST_CANVAS_WIDTH / 2) + 100, 320);
 
-   // Initialize the text, "START GAME", for the main menu.
    var startGame = new TextString((CONST_CANVAS_WIDTH / 2) + 125, 320,
                               CONST_FONT_SIZE_SMALL, "default", "START GAME", "Small");
 
-   // Initialize the text, "CREDITS", for the main menu.
    var credits = new TextString((CONST_CANVAS_WIDTH / 2) + 125, 350,
                                  CONST_FONT_SIZE_SMALL, "default", "CREDITS", "Small");
 
-   // Initialize a third option for the main menu.
    var thirdOption = new TextString((CONST_CANVAS_WIDTH / 2) + 125, 380,
                                 CONST_FONT_SIZE_SMALL, "default", "OBSCENITIES: OFF  ON", "Small");
 
-   // Create an icon to show the 'W' key to the player.
    var keyIconW = new StaticMenuObject(
       CONST_FONT_SIZE_LARGE + 10,                       // x
       (CONST_CANVAS_HEIGHT / 2) + CONST_DIM_XLARGE - 4, // y
       "KeyIconW"                                        // imageHandle
       );
 
-   // Create an icon to show the 'A' key to the player.
    var keyIconA = new StaticMenuObject(
       6,                                                                    // x
       (CONST_CANVAS_HEIGHT / 2) + CONST_DIM_XLARGE + CONST_FONT_SIZE_LARGE, // y
       "KeyIconA"                                                            // imageHandle
       );
 
-   // Create an icon to show the 'S' key to the player.
    var keyIconS = new StaticMenuObject(
       CONST_FONT_SIZE_LARGE + 10,                                           // x
       (CONST_CANVAS_HEIGHT / 2) + CONST_DIM_XLARGE + CONST_FONT_SIZE_LARGE, // y
       "KeyIconS"                                                            // imageHandle
       );
 
-   // Create an icon to show the 'D' key to the player.
    var keyIconD = new StaticMenuObject(
       CONST_DIM_MEDIUM + 14,                                                // x
       (CONST_CANVAS_HEIGHT / 2) + CONST_DIM_XLARGE + CONST_FONT_SIZE_LARGE, // y
       "KeyIconD"                                                            // imageHandle
       );
 
-   // Create an icon to show the 'Enter' key to the player.
    var keyIconEnter = new StaticMenuObject(
       CONST_DIM_LARGE, // x
       (CONST_CANVAS_HEIGHT / 2) + CONST_DIM_XLARGE - CONST_FONT_SIZE_LARGE, // y
       "KeyIconEnter" // imageHandle
       );
 
-   // Create a toggle box, location dependent on the game's obscenities setting.
    if (a_deersim.obscenities === CONST_FALSE) {
       a_deersim.toggleBox = new StaticMenuObject(961,
                                        thirdOption.y - 95,
@@ -295,14 +251,12 @@ function startMainMenu(a_deersim) {
                                        "ToggleBox");
    }
 
-   // If we're coming from a boss battle and need to load new background music...
    if (a_deersim.musicManager.reloadOnNextMain === CONST_TRUE) {
       playBackgroundTrackOnEnteringMainMenu(a_deersim);
    }
 
    a_deersim.musicManager.createAndDisplayMusicTicker(a_deersim);
 
-   // Create indicators for the game version and date, and add them to the objects array.
    var versionNumber
       = new TextString((CONST_CANVAS_WIDTH - (5 * CONST_FONT_SIZE_TINY)), // x
                        (CONST_CANVAS_HEIGHT - (2 * 14)) - 4,              // y
@@ -319,7 +273,6 @@ function startMainMenu(a_deersim) {
                        "5 May 2019",                                       // string
                        "Tiny");                                            // size
 
-   // Add the newly created objects to the objects array.
    a_deersim.gameObjects.push(mainMenuBox);
    a_deersim.gameObjects.push(titleBox);
    a_deersim.gameObjects.push(interstateEmblem);
@@ -337,7 +290,7 @@ function startMainMenu(a_deersim) {
    a_deersim.gameObjects.push(versionNumber);
    a_deersim.gameObjects.push(versionDate);
 
-   a_deersim.musicManager.reloadOnNextMain = CONST_FALSE; // Reset this flag.
+   a_deersim.musicManager.reloadOnNextMain = CONST_FALSE;
 }; // startMainMenu()
 
 /*-----------------------------------------------------------*\
@@ -345,24 +298,21 @@ function startMainMenu(a_deersim) {
 \*-----------------------------------------------------------*/
 var startRound = function() {
    if (deersim.state === "main") {
-      deersim.state = "round"; // Transition the game to the round state.
+      deersim.state = "round";
 
-      clearMenuObjects(deersim); // Clear main menu DialogBoxes and Cursor.
-      clearTextStrings(deersim); // Clear main menu TextStrings.
+      clearMenuObjects(deersim);
+      clearTextStrings(deersim);
 
-      playerProfile = new Profile(); // Create a new Profile.
+      playerProfile = new Profile();
 
-      deer = new Deer();              // Initialize a Deer.
-      deersim.gameObjects.push(deer); // Add the Deer to the game objects array.
+      deer = new Deer();
+      deersim.gameObjects.push(deer);
 
-      // Initialize the level and experience TextStrings.
       playerProfile.initTextStrings();
       // #TODO -- consider moving this to the Profile constructor.
 
       var mapVisibilityDurationInFrames = 300;
 
-      /* Create a balloon, image, and cursor to display the Connecticut Map to
-         the player, and then push all three objects into the game objects array. */
       var mapBalloon = new ExpiringObject(
          50,                           // x
          50,                           // y
@@ -388,70 +338,52 @@ var startRound = function() {
       deersim.gameObjects.push(initialMapCursor);
    }
    else if (deersim.state === "bossBattle") {
-      deersim.state = "round"; // Transition the game to the round state.
+      deersim.state = "round";
 
-      playerProfile.consecutiveLvls = 0; // Reset the profile's consecutive level counter.
+      playerProfile.consecutiveLvls = 0;
 
-      deersim.musicManager.backgroundTrack.pause();         // Pause the current background music.
-      deersim.musicManager.backgroundTrack.currentTime = 0; // Reset current background music to t0.
-      deersim.musicManager.loadMusic();                     // Load new background music.
-      deersim.musicManager.backgroundTrack.play();          // Play the background music.
+      deersim.musicManager.backgroundTrack.pause();
+      deersim.musicManager.backgroundTrack.currentTime = 0;
+      deersim.musicManager.loadMusic();
+      deersim.musicManager.backgroundTrack.play();
    }
 };
 
 var transitionToSA40PhaseOne = function() {
-   // Transition the game state to the transition to SA-40, phase 1.
    deersim.state = "transitionToSA40PhaseOne";
 
    deersim.backgroundManager.bgIsScrolling = CONST_FALSE;
 
-	// Create an array to store the herd of Deer following the WhiteVan.
 	var deerHerd = new Array(playerProfile.remainingDeer);
 
-	// Create a variable to store a series of images
-	// comprising the kidnapping animation.
 	var kidnappingAnimationFrames = new Array();
 
-	// Create a variable to store the prefix
-	// of all handles for the kidnapping animation.
 	var imageHandlePrefix = "kidnappingAnimation";
 
-    /* Build image handles to store in variable kidnappingAnimationFrames. |
-     | This animation consists of 19 frames.                               |
-     | Variables used in this for loop:                                    |
-     | i:           iteration counter.                                     |
-     | iString:     the value of i, in the form of a string.               |
-     | imageHandle: a string used to identify each HTML                    |
-     |                object stored in the animation.                      */
 	for (var i = 0, iString = "", imageHandle = ""; i < 19; i++) {
-		iString = i.toString();                          // Update iString.
-		imageHandle = imageHandlePrefix.concat(iString); // Build image handle.
-		kidnappingAnimationFrames[i] = imageHandle;      // Add to list.
+		iString = i.toString();
+		imageHandle = imageHandlePrefix.concat(iString);
+		kidnappingAnimationFrames[i] = imageHandle;
 	}
 
-	// Remove the active deer from play by...
-    var deerIndex = deersim.gameObjects.indexOf(deer); // ...identifying its index.
-    deersim.gameObjects.splice(deerIndex, 1);          // ...removing it from the array.
+    var deerIndex = deersim.gameObjects.indexOf(deer);
+    deersim.gameObjects.splice(deerIndex, 1);
 
-	var vehicle = 0; // Create a variable to iterate through vehicles in play.
+	var vehicle = 0;
 
-    while (vehicle < deersim.vehicles.length) {            // Iterate through vehicles in play.
-      if (deersim.vehicles[vehicle] instanceof WhiteVan) { // If a vehicle is a WhiteVan...
-            deersim.vehicles.splice(vehicle, 1);           // ...remove it from play.
+    while (vehicle < deersim.vehicles.length) {
+      if (deersim.vehicles[vehicle] instanceof WhiteVan) {
+            deersim.vehicles.splice(vehicle, 1);
 		}
 		else {
-			vehicle++; // Otherwise, on to the next vehicle.
+			vehicle++;
 		}
 	}
 
-   // Construct AnimationBlock object to store the first transition animation.
-   // (terrorists jump out of WhiteVan and kidnap the active Deer)
    transitionAnimation = new AnimationBlock(deer.x - 62, deer.y - 66, 128, 19, "KidnappingAnimation");
 
-   // Add the first transition animation to the objects array.
    deersim.gameObjects.push(transitionAnimation);
 
-   // Transition the game state to the transition to SA-40, phase 2.
    deersim.state = "transitionToSA40PhaseTwo";
 };
 
@@ -460,11 +392,9 @@ var transitionToSA40PhaseOne = function() {
  | (Kidnappers jump out of WhiteVan and kidnap the active deer.) |
 \*---------------------------------------------------------------*/
 var transitionToSA40PhaseTwo = function() {
-   transitionAnimation.update(); // Update the transition animation.
+   transitionAnimation.update();
 
-   // If the animation is over...
    if (transitionAnimation.frameCounter >= (7 * transitionAnimation.length)) {
-      // Transition the game state to phase three of the SA-40 transition.
       transitionToSA40PhaseThree(playerProfile.remainingDeer);
    }
 };
@@ -475,36 +405,30 @@ var transitionToSA40PhaseTwo = function() {
  | -- Create a herd of Deer to chase after the WhiteVan.                       |
 \*-----------------------------------------------------------------------------*/
 var transitionToSA40PhaseThree = function(remainingDeer) {
-   // Transition the game state to the transition to SA-40, phase 3.
    deersim.state = "transitionToSA40PhaseThree";
 
-   clearFinishedAnimations(); // Remove the recently-finished AnimationBlock from play.
+   clearFinishedAnimations();
 
-   // Create a new WhiteVan object to represent the
-   // van which has been removed with the animation.
    var whiteVan = new WhiteVan(6, 0);
 
-   // Adjust the position of the new WhiteVan for a seamless animation.
    whiteVan.x = transitionAnimation.x + 38;
    whiteVan.y -= 2;
 
-   deersim.vehicles.push(whiteVan); // Add the WhiteVan to the vehicles array.
+   deersim.vehicles.push(whiteVan);
 
-   var deerHerd   = new Array(remainingDeer); // Create a herd of deer.
-   var adjustment = 0; // Used in the upcoming loop.
+   var deerHerd   = new Array(remainingDeer);
+   var adjustment = 0;
 
-   for (var i = 0; i < deerHerd.length; i++) { // For every position in the deer herd array,
-      // Generate a unique adjustment value for the new Deer's x and y position.
+   for (var i = 0; i < deerHerd.length; i++) {
       adjustment = (Math.random() - 0.5) * 40;
 
-      deerHerd[i] = new Deer();                       // Generate a new Deer.
-      deerHerd[i].x = -64 - (80 * i) + adjustment;    // Adjust new Deer's x position.
-      deerHerd[i].y = whiteVan.y + adjustment + 75; // Adjust new Deer's y position.
+      deerHerd[i] = new Deer();
+      deerHerd[i].x = -64 - (80 * i) + adjustment;
+      deerHerd[i].y = whiteVan.y + adjustment + 75;
 
-      deersim.gameObjects.push(deerHerd[i]); // Add the new Deer to the objects array.
+      deersim.gameObjects.push(deerHerd[i]);
    }
 
-   // Transition the game state to the transition to SA-40, phase 4.
    deersim.state = "transitionToSA40PhaseFour";
 };
 
@@ -514,36 +438,33 @@ var transitionToSA40PhaseThree = function(remainingDeer) {
  | -- Move all of the deer in the herd offscreen to the right.          |
 \*----------------------------------------------------------------------*/
 var transitionToSA40PhaseFour = function() {
-   var wvsInPlay = 0; // Will store the number of WhiteVans currently in play.
+   var wvsInPlay = 0;
 
-   for (var vehicle in deersim.vehicles) { // For every vehicle currently in play,
-      if (deersim.vehicles[vehicle] instanceof WhiteVan) { // If the vehicle is a WhiteVan,
-         deersim.vehicles[vehicle].x += 3; // Then move it to the right by 3 pixels.
+   for (var vehicle in deersim.vehicles) {
+      if (deersim.vehicles[vehicle] instanceof WhiteVan) {
+         deersim.vehicles[vehicle].x += 3;
 
          wvsInPlay++;
       }
    }
 
-   var deerInPlay = 0; // Will store the number of Deer currently in play.
+   var deerInPlay = 0;
 
-   for (var gameObject in deersim.gameObjects) { // For every object currently in play,
-      if (deersim.gameObjects[gameObject] instanceof Deer) { // If the object is a Deer,
-         deersim.gameObjects[gameObject].x += 3; // Then move it to the right by 3 pixels.
+   for (var gameObject in deersim.gameObjects) {
+      if (deersim.gameObjects[gameObject] instanceof Deer) {
+         deersim.gameObjects[gameObject].x += 3;
 
          deerInPlay++;
 
-         // If the Deer has run offscreen to the right...
          if (deersim.gameObjects[gameObject].x > CONST_CANVAS_WIDTH + 100) {
-            deersim.gameObjects.splice(gameObject, 1); // ...then remove it from the objects array.
+            deersim.gameObjects.splice(gameObject, 1);
 
             deerInPlay--;
          }
       }
    }
 
-   // If all of the Deer and the WhiteVan have exited the screen to the right...
    if ((deerInPlay === 0) && (wvsInPlay === 0)) {
-      // Transition the game state to phase five of the SA-40 transition.
       transitionToSA40PhaseFive();
    }
 };
@@ -555,30 +476,24 @@ var transitionToSA40PhaseFour = function() {
  | -- Create a new WhiteVan, offscreen to the left.             |
 \*--------------------------------------------------------------*/
 var transitionToSA40PhaseFive = function() {
-   // Transition the game state to the transition to SA-40, phase 5.
    deersim.state = "transitionToSA40PhaseFive";
 
-   // Change the BackgroundManager's environment to SA-40.
    deersim.backgroundManager.setEnvironment("sa40");
 
-   // Change the MusicManager's environment to SA-40.
    deersim.musicManager.environment = "sa40";
 
-   clearAllPreviousGameObjects(); // Remove all objects, vehicles, & powerups in play.
+   clearAllPreviousGameObjects();
 
-   // Pause the current background music and load new background music for SA-40.
    deersim.musicManager.backgroundTrack.pause();
    deersim.musicManager.loadMusic();
 
-   deersim.musicManager.backgroundTrack.play(); // Play the background music.
+   deersim.musicManager.backgroundTrack.play();
 
-   // Create a new WhiteVan, which is carrying the kidnapped Deer.
    var whiteVan = new WhiteVan(2, 0);
 
-   whiteVan.x = -128;               // Move the WhiteVan offscreen to the left.
-   deersim.vehicles.push(whiteVan); // Add the WhiteVan to the vehicles array.
+   whiteVan.x = -128;
+   deersim.vehicles.push(whiteVan);
 
-   // Transition the game state to the transition to SA-40, phase 6.
    deersim.state = "transitionToSA40PhaseSix";
 };
 
@@ -586,14 +501,10 @@ var transitionToSA40PhaseFive = function() {
  | Maintenance phase during which WhiteVan enters screen from the left. |
 \*----------------------------------------------------------------------*/
 var transitionToSA40PhaseSix = function() {
-   /* At this point in the transition to SA-40, we make the  *
-    * assumption that the only vehicle in the vehicles array *
-    * is a WhiteVan which was created in phase five.         */
-   for (var vehicle in deersim.vehicles) { // For each vehicle in the vehicles array,
-      deersim.vehicles[vehicle].x += 3;    // Move the vehicle slightly to the right,
+   for (var vehicle in deersim.vehicles) {
+      deersim.vehicles[vehicle].x += 3;
 
-      if (deersim.vehicles[vehicle].x >= 100) { // If the WhiteVan has reached 100 pixels in x...
-         // ...then transition the game state to phase seven of the SA-40 transition.
+      if (deersim.vehicles[vehicle].x >= 100) {
          transitionToSA40PhaseSeven();
       }
    }
@@ -606,47 +517,28 @@ var transitionToSA40PhaseSix = function() {
  | -- Replace the existing WhiteVan with the new AnimationBlock. |
 \*---------------------------------------------------------------*/
 var transitionToSA40PhaseSeven = function() {
-   // Transition the game state to the transition to SA-40, phase 7.
    deersim.state = "transitionToSA40PhaseSeven";
 
-   // Create a variable to store a series of images
-	// comprising the dropoff animation.
 	var dropoffAnimationFrames = new Array();
 
-   // Create a variable to store the prefix
-	// of all handles for the dropoff animation.
 	var imageHandlePrefix = "dropoffAnimation";
 
-   /* Build image handles to store in variable dropoffAnimationFrames. |
-     | This animation consists of 14 frames.                           |
-     | Variables used in this for loop:                                |
-     | i:           iteration counter.                                 |
-     | iString:     the value of i, in the form of a string.           |
-     | imageHandle: a string used to identify each HTML                |
-     |                object stored in the animation.                  */
 	for (var i = 0, iString = "", imageHandle = ""; i < 14; i++) {
-		iString = i.toString();                          // Update iString.
-		imageHandle = imageHandlePrefix.concat(iString); // Build image handle.
-		dropoffAnimationFrames[i] = imageHandle;         // Add to list.
+		iString = i.toString();
+		imageHandle = imageHandlePrefix.concat(iString);
+		dropoffAnimationFrames[i] = imageHandle;
 	}
 
-   /* At this point in the transition to SA-40, we make the  *
-    * assumption that the only vehicle in the vehicles array *
-    * is an WhiteVan which was created in phase five.        */
-   deersim.vehicles.splice(0, 1); // Remove the WhiteVan from play.
+   deersim.vehicles.splice(0, 1);
 
-   // Construct AnimationBlock object to store the second transition animation.
-   // (WhiteVan stops and drops off the previously kidnapped Deer)
-   transitionAnimation = new AnimationBlock(59,  // x = hardcoded constant from deersim classic.
-                                            526, // y based on previous location of WhiteVan.
+   transitionAnimation = new AnimationBlock(59,
+                                            526,
                                             128,
                                             14,
                                             "DropOffAnimation");
 
-   // Add the second transition animation to the objects array.
    deersim.gameObjects.push(transitionAnimation);
 
-   // Transition the game state to the transition to SA-40, phase 8.
    deersim.state = "transitionToSA40PhaseEight";
 };
 
@@ -655,34 +547,27 @@ var transitionToSA40PhaseSeven = function() {
  | (Kidnappers drop the deer out of the WhiteVan, onto the road.) |
 \*----------------------------------------------------------------*/
 var transitionToSA40PhaseEight = function() {
-   transitionAnimation.update(); // Update the transition animation.
+   transitionAnimation.update();
 
-   // If the animation is over...
    if (transitionAnimation.frameCounter >= (7 * transitionAnimation.length)) {
-      // Transition the game state to phase nine of the SA-40 transition.
       transitionToSA40PhaseNine();
    }
 };
 
 var transitionToSA40PhaseNine = function() {
-   // Transition the game state to the transition to SA-40, phase 9.
    deersim.state = "transitionToSA40PhaseNine";
 
-   clearFinishedAnimations(); // Remove the recently-finished AnimationBlock from play.
+   clearFinishedAnimations();
 
-   // Create a new WhiteVan, which has just dropped off the kidnapped Deer.
    var whiteVan = new WhiteVan(2, 0);
 
-   // Move the WhiteVan's x position to match that of the van in the AnimationBlock.
    whiteVan.x = 100;
 
-   var deerStill = new DeerStill(140, 590); // Create a new deer, standing still.
+   var deerStill = new DeerStill(140, 590);
 
-   // Add the newly created objects to their respective arrays.
    deersim.vehicles.push(whiteVan);
    deersim.gameObjects.push(deerStill);
 
-   // Transition the game state to the transition to SA-40, phase 10.
    deersim.state = "transitionToSA40PhaseTen";
 };
 
@@ -694,33 +579,26 @@ var transitionToSA40PhaseNine = function() {
  | -- Create a new active deer.                                      |
 \*-------------------------------------------------------------------*/
 var transitionToSA40PhaseTen = function() {
-   /* At this point in the transition to SA-40, we make the  *
-    * assumption that the only vehicle in the vehicles array *
-    * is a WhiteVan which was created in phase nine.         */
-   for (var vehicle in deersim.vehicles) { // For each vehicle in the vehicles array...
-      deersim.vehicles[vehicle].x += 3;    // Move the vehicle slightly to the right...
+   for (var vehicle in deersim.vehicles) {
+      deersim.vehicles[vehicle].x += 3;
    }
 
-   // If the WhiteVan has finished driving offscreen...
    if (deersim.vehicles.length === 0) {
-      deersim.state = "round"; // ...then set the game state back to a round of play.
+      deersim.state = "round";
 
-      // Search the objects array for extraneous transition objects which should be removed.
       for (gameObject in deersim.gameObjects) {
          if ((deersim.gameObjects[gameObject] instanceof DeerStill)
           || (deersim.gameObjects[gameObject] instanceof Deer)) {
-            // Remove extraneous transition objects from the array.
             deersim.gameObjects.splice(gameObject, 1);
          }
       }
 
       deersim.backgroundManager.bgIsScrolling = CONST_TRUE;
 
-      deer = new Deer();              // Create a new Deer.
-      deer.x = 100;                   // Move the Deer outside of the 'initializing' state range...
-                                      // ...and to match the location of the prior DeerStill object.
-      deer.clothing = "bag";          // Trigger the Deer to wear the bag it was made to.
-      deersim.gameObjects.push(deer); // Add the Deer to the game objects array.
+      deer = new Deer();
+      deer.x = 100;
+      deer.clothing = "bag";
+      deersim.gameObjects.push(deer);
    }
 };
 
@@ -729,24 +607,24 @@ var transitionToSA40PhaseTen = function() {
  | Transitions the game to the 'round' state.      |
 \*-------------------------------------------------*/
 var unpause = function() {
-   deersim.state = pauseStateBuffer; // Transition the game to the state from prior to pause.
-   deersim.pauseTimer++;             // Start the pause timer.
-   clearMenuObjects(deersim);        // Remove pause menu DialogBox and TextStrings.
-   clearTextStrings(deersim);        // Remove pause menu TextStrings.
+   deersim.state = pauseStateBuffer;
+   deersim.pauseTimer++;
+   clearMenuObjects(deersim);
+   clearTextStrings(deersim);
 
    deersim.backgroundManager.bgIsScrolling = CONST_TRUE;
 
-   for (var soundEffect in deersim.soundEffects) {            // For each of the game's sound effects...
-      if ((deersim.soundEffects[soundEffect].paused)          // If the sound effect is paused...
-       && (deersim.soundEffects[soundEffect].currentTime > 0) // ...and it was previously started...
-       && !(deersim.soundEffects[soundEffect].ended)) {       // ...and it has not yet ended...
-         deersim.soundEffects[soundEffect].play();            // Continue playing the sound effect.
+   for (var soundEffect in deersim.soundEffects) {
+      if ((deersim.soundEffects[soundEffect].paused)
+       && (deersim.soundEffects[soundEffect].currentTime > 0)
+       && !(deersim.soundEffects[soundEffect].ended)) {
+         deersim.soundEffects[soundEffect].play();
       }
    }
 
-   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_LOW].pause();         // Pause in case already playing.
-   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_LOW].currentTime = 0; // Re-seek to t0.
-   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_LOW].play();          // MenuSelectionMinus12Semitones
+   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_LOW].pause();
+   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_LOW].currentTime = 0;
+   deersim.soundEffects[CONST_SOUND_INDEX_MENU_SELECTION_LOW].play();
 };
 
 // ---- End of function declarations. ----

--- a/deersim/vehicles.js
+++ b/deersim/vehicles.js
@@ -13,20 +13,18 @@
  | @param float speed -- this DeerTruck's speed.          |
 \*--------------------------------------------------------*/
 function DeerTruck(lane, speed) {
-   this.state          = "default"; // Assign this DeerTruck to the default state.
-   this.lane           = lane;      // Assign this DeerTruck's lane.
-   this.speed          = speed;     // Assign this DeerTruck's speed.
-   this.d              = 64;        // Assign this DeerTruck's dimension.
-   this.value          = 7500;      // Assign this DeerTruck's value.
-   this.collisionWidth = 41;        // Assign this DeerTruck's collision width.
-   
-   // Assign this DeerTruck's x position as adjacent to the canvas boundary.
+   this.state          = "default";
+   this.lane           = lane;
+   this.speed          = speed;
+   this.d              = 64;
+   this.value          = 7500;
+   this.collisionWidth = 41;
+
    this.x = deersim.canvas.width - this.d;
-   
-   // Assign this DeerTruck's y position based on its lane.
+
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane);
-   
-   this.yVelocity = -7; // Initialze a y velocity in case this DeerTruck dies.
+
+   this.yVelocity = -7;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -39,24 +37,22 @@ function DeerTruck(lane, speed) {
  |                                  used in collisionDetection().             |
 \*----------------------------------------------------------------------------*/
 function Vehicle(lane, speed, type, value, collisionWidth) {
-   this.state          = "default";      // Assign this Vehicle to the default state.
-   this.lane           = lane;           // Assign this Vehicle's lane.
-   this.speed          = speed;          // Assign this Vehicle's speed.
-   this.type           = type;           // Assign this Vehicle's type.
-   this.d              = 128;            // Assign this Vehicle's dimension.
-   this.value          = value;          // Assign this Vehicle's value.
-   this.collisionWidth = collisionWidth; // Assign this Vehicle's collision width.
-   
-   // Assign this Vehicle's x position as adjacent to the canvas boundary.
+   this.state          = "default";
+   this.lane           = lane;
+   this.speed          = speed;
+   this.type           = type;
+   this.d              = 128;
+   this.value          = value;
+   this.collisionWidth = collisionWidth;
+
    this.x = CONST_CANVAS_WIDTH - this.d;
-   
-   // Assign this Vehicle's y position based on its lane.
+
    this.y = CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane) - 64;
-   
-   this.yVelocity       = -7; // Initialze a y velocity in case this Vehicle dies.
-   this.rotationCounter = 0;  // Controls this Vehicle's angle when it dies.
-   this.angleOfRotation = 0;  // Tracks this Vehicle's angle when it dies.
-   this.imageHandle     = ""; // Image handle variable for this Vehicle.
+
+   this.yVelocity       = -7;
+   this.rotationCounter = 0;
+   this.angleOfRotation = 0;
+   this.imageHandle     = "";
 };
 
 /*--------------------------------------------------------*\
@@ -66,18 +62,14 @@ function Vehicle(lane, speed, type, value, collisionWidth) {
  | @param float speed -- this WhiteVan's speed.           |
 \*--------------------------------------------------------*/
 function WhiteVan(lane, speed) {
-   this.lane           = lane;      // Assign this WhiteVan's lane.
-   this.speed          = speed;     // Assign this WhiteVan's speed.
-   this.d              = 128;       // Assign this WhiteVan's dimension.
-   this.collisionWidth = 79;        // Assign this WhiteVan's collision width.
-   
+   this.lane           = lane;
+   this.speed          = speed;
+   this.d              = 128;
+   this.collisionWidth = 79;
+
    // #TODO -- Make all vehicles generate offscreen as opposed to onscreen.
-   // Assign this WhiteVan's x position as adjacent to the canvas boundary.
    this.x = deersim.canvas.width - this.d;
-   
-   /* Assign this WhiteVan's y position based on its lane. |
-   |  Subtract an extra 64 pixels due to the increased     |
-   |  size of the WhiteVan (128x128 as opposed to 64x64).  */
+
    this.y = (CONST_LANE_0_BASE - (CONST_LANE_HEIGHT * this.lane) - 64);
 };
 
@@ -90,19 +82,19 @@ function WhiteVan(lane, speed) {
 \*-----------------------*/
 DeerTruck.prototype.draw = function() {
    deersim.canvasContext.drawImage(document.getElementById("DeerTruck"),
-                           this.x, this.y); // Draw this DeerTruck's image.
+                           this.x, this.y);
 };
 
 /*-------------------------*\
  | Updates this DeerTruck. |
 \*-------------------------*/
 DeerTruck.prototype.update = function() {
-   if (this.state === "default") // If this DeerTruck is in the default state,
-      this.x -= this.speed;      // Move this DeerTruck to the left, proportional to its speed.
-   else if (this.state === "dying") { // If this DeerTruck is dying,
-      this.x += 5;                    // Propel this DeerTruck to the right.
-      this.y += this.yVelocity;       // Propel this DeerTruck up or down, as...
-      this.yVelocity += 0.1;          // ...its y velocity continually increases.
+   if (this.state === "default")
+      this.x -= this.speed;
+   else if (this.state === "dying") {
+      this.x += 5;
+      this.y += this.yVelocity;
+      this.yVelocity += 0.1;
    }
 };
 
@@ -110,22 +102,19 @@ DeerTruck.prototype.update = function() {
  | Draws this Vehicle. |
 \*---------------------*/
 Vehicle.prototype.draw = function() {
-   this.imageHandle = this.type; // Use this Vehicle's type as a base image handle.
-   
-   // Use i to determine an angle of rotation based on this Vehicle's rotation counter.
+   this.imageHandle = this.type;
+
    var i = this.rotationCounter / 3;
    i = Math.ceil(i);
-   if (i == 0) // In the case where rotationCounter = 0, i = 0 which is undesirable.
-      i = 12;  // Setting i to 12 in this case yields an equal distribution of angles.
+   if (i == 0)
+      i = 12;
    this.angleOfRotation = (i - 1) * 30;
-   
-   // If this Vehicle is dying, concatenate its angle of rotation to its image handle...
+
    if (this.state === "dying") {
       this.imageHandle = this.imageHandle.concat("_C_");
       this.imageHandle = this.imageHandle.concat(this.angleOfRotation);
    }
-   
-   // Display this Vehicle's current frame.
+
    deersim.canvasContext.drawImage(document.getElementById(this.imageHandle), this.x, this.y);
 };
 
@@ -133,15 +122,14 @@ Vehicle.prototype.draw = function() {
  | Updates this Vehicle. |
 \*-----------------------*/
 Vehicle.prototype.update = function() {
-   if (this.state === "default") // If this Vehicle is in the default state,
-      this.x -= this.speed;      // Move this Vehicle to the left, proportional to its speed.
-   else if (this.state === "dying") { // If this Vehicle is dying,
-      this.x += 5;                    // Propel this Vehicle to the right.
-      this.y += this.yVelocity;       // Propel this Vehicle up or down, as...
-      this.yVelocity += 0.1;          // ...its y velocity continually increases.
+   if (this.state === "default")
+      this.x -= this.speed;
+   else if (this.state === "dying") {
+      this.x += 5;
+      this.y += this.yVelocity;
+      this.yVelocity += 0.1;
    }
-   
-   // Increment this Vehicle's rotation counter, and reset the counter if it has elapsed.
+
    this.rotationCounter++;
    if (this.rotationCounter > 35) {
       this.rotationCounter = 0;
@@ -153,13 +141,12 @@ Vehicle.prototype.update = function() {
 \*----------------------*/
 WhiteVan.prototype.draw = function() {
    deersim.canvasContext.drawImage(document.getElementById("WhiteVan"),
-                           this.x, this.y); // Draw the WhiteVan's image.
+                           this.x, this.y);
 };
 
 /*------------------------*\
  | Updates this WhiteVan. |
 \*------------------------*/
 WhiteVan.prototype.update = function() {
-   // Move this WhiteVan to the left, proportional to its speed.
    this.x -= this.speed;
 };


### PR DESCRIPTION
I was a young lad (25, specifically) when I originally wrote the deersim module, and I hadn't had a professional software engineering job yet. At the time, I thought it was a good idea to essentially put pseudocode descriptions of all of my algorithms into comments right next to the code itself. The idea was that lots of comments meant more clarity about how the code is meant to work.

In reality, though, I've since learned that most of these comments aren't helpful and they clutter the codebase terribly. So, with this change I am pulling almost all of these pseudocode comments out of the deersim module. This change reduces the number of test failures reported by `test_line_lengths_of_JavaScript_files.ps1` from 59 to 22.

I tried my best to leave in certain comments that are actually helpful (e.g. explaining what magic numbers mean), which amounted to about 3% of all of the comments.

That said, there's generally a lot of cleanup to do in the deersim module (fix magic numbers, improve names of things, use more constants more often, etc.), so I'm not being too picky about code clarity at the moment.