### PR TITLE
[deersim] Fix whitespace and line lengths in initializeGame.js

### DIFF
--- a/deersim/initializeGame.js
+++ b/deersim/initializeGame.js
@@ -3,62 +3,64 @@
 \*-------------------------------------------*/
 function initializeGame(a_deersim)
 {
-    a_deersim.gameObjects  = new Array();
-    a_deersim.vehicles     = new Array();
-    a_deersim.obstacles    = new Array();
-    a_deersim.powerups     = new Array();
-    a_deersim.projectiles  = new Array();
-    a_deersim.soundEffects = new Array();
-    a_deersim.voices       = new Array();
+   a_deersim.gameObjects  = new Array();
+   a_deersim.vehicles     = new Array();
+   a_deersim.obstacles    = new Array();
+   a_deersim.powerups     = new Array();
+   a_deersim.projectiles  = new Array();
+   a_deersim.soundEffects = new Array();
+   a_deersim.voices       = new Array();
 
-    populateJavascriptArrayWithAudioFromHtmlContainer("soundEffects", a_deersim.soundEffects); // TODO: Magic values.
+   // TODO: Magic values:
+   populateJavascriptArrayWithAudioFromHtmlContainer("soundEffects", a_deersim.soundEffects);
 
-    a_deersim.obscenities    = CONST_FALSE;
-    a_deersim.realTimeEngine = CONST_TRUE; // #TODO -- documentation
+   a_deersim.obscenities    = CONST_FALSE;
+   a_deersim.realTimeEngine = CONST_TRUE; // #TODO -- documentation
 
-    populateJavascriptArrayWithAudioFromHtmlContainer("voices", a_deersim.voices); // TODO: Magic values.
+   // TODO: Magic values:
+   populateJavascriptArrayWithAudioFromHtmlContainer("voices", a_deersim.voices);
 
-    a_deersim.generator         = new Generator();
-    a_deersim.messageGenerator  = new MessageGenerator();
-    a_deersim.backgroundManager = new BackgroundManager();
-    a_deersim.musicManager      = new MusicManager(CONST_ENVIRONMENT_I84);
-    a_deersim.roadManager       = new RoadManager();
-    a_deersim.touchManager      = new TouchManager();
+   a_deersim.generator         = new Generator();
+   a_deersim.messageGenerator  = new MessageGenerator();
+   a_deersim.backgroundManager = new BackgroundManager();
+   a_deersim.musicManager      = new MusicManager(CONST_ENVIRONMENT_I84);
+   a_deersim.roadManager       = new RoadManager();
+   a_deersim.touchManager      = new TouchManager();
 
-    a_deersim.creditsMenu = new TextBox(((CONST_CANVAS_WIDTH / 2) - 224), 108);
-    // #TODO -- 224 is half of the credits menu width. Find a way to not hardcode it.
+   a_deersim.creditsMenu = new TextBox(((CONST_CANVAS_WIDTH / 2) - 224), 108);
+   // #TODO -- 224 is half of the credits menu width. Find a way to not hardcode it.
 
-    a_deersim.debuggerEnabled = CONST_FALSE;
+   a_deersim.debuggerEnabled = CONST_FALSE;
 
-    a_deersim.frameTimes = new Array();
+   a_deersim.frameTimes = new Array();
 
-    a_deersim.liveDebugger = new LiveDebugger(a_deersim);
+   a_deersim.liveDebugger = new LiveDebugger(a_deersim);
 
-    a_deersim.musicCounter      = 0;
-    a_deersim.pauseTimer        = 0;
-    a_deersim.killCounter       = 0;
-    a_deersim.projectileCounter = 0;
-    a_deersim.deltaT            = 0; // #TODO -- documentation
+   a_deersim.musicCounter      = 0;
+   a_deersim.pauseTimer        = 0;
+   a_deersim.killCounter       = 0;
+   a_deersim.projectileCounter = 0;
+   a_deersim.deltaT            = 0; // #TODO -- documentation
 
-    a_deersim.timeStep = 1000 / 60; // #TODO -- documentation
+   a_deersim.timeStep = 1000 / 60; // #TODO -- documentation
 
-    a_deersim.killCounter++;
+   a_deersim.killCounter++;
 }; // initializeGame
 
 function populateJavascriptArrayWithAudioFromHtmlContainer(containerId, arrayToPopulate)
 {
-    const contents = document.getElementById(containerId).children;
-    const localNameAudio = "audio";
+   const contents = document.getElementById(containerId).children;
+   const localNameAudio = "audio";
 
-    var element;
-    var arrayIndex = 0;
-    for (var containerIndex in contents)
-    {
-        element = contents[containerIndex];
-        if (element.localName === localNameAudio)
-        {
-            arrayToPopulate[arrayIndex] = element;
-            ++arrayIndex;
-        }
-    }
+   var element;
+   var arrayIndex = 0;
+   for (var containerIndex in contents)
+   {
+      element = contents[containerIndex];
+      if (element.localName === localNameAudio)
+      {
+         arrayToPopulate[arrayIndex] = element;
+         ++arrayIndex;
+      }
+   }
 } // populateJavascriptArrayWithAudioFromHtmlContainer()


### PR DESCRIPTION
The reason that `initializeGame()` and `initializeCanvas()` are each in their own standalone files now is an artifact left over from when I initially implemented the few automated tests which do exist in the deersim module. Ultimately, I will probably move them back into larger files, but that's not a high priority for me right now.

In any case, it looks like when I created `initializeGame()`, I didn't notice that this module uses three space indentation, and instead wrote the file in my more-typical four space indentation.

This change resets the indentation to three spaces, and more importantly it moves a couple of TODO comments so that the total number of test failures reported by `test_line_lengths_of_JavaScript_files.ps1` is reduced from 8 to 6.