### PR TITLE
[deersim] Split test comments longer than 100 characters into multiple lines.

### DIFF
--- a/deersim/tests/deersim.test.js
+++ b/deersim/tests/deersim.test.js
@@ -285,7 +285,9 @@ function expectArrayIsPopulatedWithAudioReferences(arrayUnderTest, expectedSourc
 function initializeCanvasAndGame()
 {
     const testDeerSim = new DeerSim();
-    initializeCanvas(testDeerSim); // TODO: Consider making production code fail initializeGame() if initializeCanvas() hasn't completed.
+    /* TODO: Consider making production code fail initializeGame()
+        if initializeCanvas() hasn't completed: */
+    initializeCanvas(testDeerSim);
     initializeGame(testDeerSim);
     return testDeerSim;
 } // initializeCanvasAndGame()

--- a/deersim/tests/resources/importsAndExports/transitions.js
+++ b/deersim/tests/resources/importsAndExports/transitions.js
@@ -19,7 +19,9 @@ const Cursor = deerSim.Cursor;
 const splicingFunctions = require('./splicingFunctions');
 const clearMenuObjects = splicingFunctions.clearMenuObjects;
 const clearTextStrings = splicingFunctions.clearTextStrings;
-// TODO: Consider adding more granular testing for the code in the real playBackgroundTrackOnEnteringMainMenu().
+/* TODO: Consider adding more granular testing for the code
+    in the real playBackgroundTrackOnEnteringMainMenu(). */
 
 const testFunctions = require('../resources/testFunctions');
-const playBackgroundTrackOnEnteringMainMenu = testFunctions.playBackgroundTrackOnEnteringMainMenu; // TODO: Needs to be more granular.
+// TODO: Needs to be more granular:
+const playBackgroundTrackOnEnteringMainMenu = testFunctions.playBackgroundTrackOnEnteringMainMenu;


### PR DESCRIPTION
This change rearranges three existing TODO comments in the deersim module's test code to only comprise lines of code less than 100 characters long. This change reduces the number of test failures reported by `test_line_lengths_of_JavaScript_files.ps1` from 5 to 2.