### PR TITLE
[high_points] Fix year strings displaying squished together and indistinguishable from one another.

### DIFF
--- a/high_points.html
+++ b/high_points.html
@@ -1,11 +1,14 @@
 <html>
     <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
         <title>United States High Points</title>
+
         <link rel="stylesheet" href="high_points/high_points_style.css" />
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Oswald&display=swap">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Oswald&display=swap" />
+
         <script type="text/javascript" src="high_points/constants.js"></script>
         <script type="text/javascript" src="high_points/getMapContent.js"></script>
         <script type="text/javascript" src="high_points/mapFunctions.js"></script>

--- a/high_points.html
+++ b/high_points.html
@@ -2,7 +2,10 @@
     <head>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
         <title>United States High Points</title>
-        <link href="high_points/high_points_style.css" rel="stylesheet" />
+        <link rel="stylesheet" href="high_points/high_points_style.css" />
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Oswald&display=swap">
         <script type="text/javascript" src="high_points/constants.js"></script>
         <script type="text/javascript" src="high_points/getMapContent.js"></script>
         <script type="text/javascript" src="high_points/mapFunctions.js"></script>

--- a/high_points/high_points_style.css
+++ b/high_points/high_points_style.css
@@ -28,7 +28,7 @@
 /* Styling for each year string. */
 .year-string {
     color: #FFFFFF;
-    font-family: Impact;
+    font-family: Oswald;
     font-size: 30px;
 }
 

--- a/high_points/tests/html.test.js
+++ b/high_points/tests/html.test.js
@@ -20,30 +20,30 @@ beforeAll(() => {
 
 test(`the HTML head contains the page title`, () => {
     const elementTypeTitle = "title";
-    const title = document.head.querySelector(elementTypeTitle);
+    const titleElement = document.head.querySelector(elementTypeTitle);
     const expectedPageTitle = "United States High Points";
-    expect(title.textContent).toBe(expectedPageTitle);
+    expect(titleElement.textContent).toBe(expectedPageTitle);
 }); /* the HTML head contains the page title */
 
 test(`the HTML head contains preconnect links for the year string font`, () => {
     const relationship = "[rel=\"preconnect\"]";
     const googleAPIsSelector = kElementTypeLink + relationship + googleAPIsUrl;
-    const googleAPIsLink = document.head.querySelector(googleAPIsSelector);
+    const googleAPIsLinkElement = document.head.querySelector(googleAPIsSelector);
     const crossOriginAttribute = "[crossorigin]";
     const gStaticSelector = kElementTypeLink + relationship + gStaticUrl + crossOriginAttribute;
-    const gStaticLink = document.head.querySelector(gStaticSelector);
-    expect(isUnpopulated(googleAPIsLink)).toBe(false);
-    expect(isUnpopulated(gStaticLink)).toBe(false);
+    const gStaticLinkElement = document.head.querySelector(gStaticSelector);
+    expect(isUnpopulated(googleAPIsLinkElement)).toBe(false);
+    expect(isUnpopulated(gStaticLinkElement)).toBe(false);
 }); /* the HTML head contains preconnect links for the year string font */
 
 test(`the HTML head contains the stylesheets necessary to render the user interface`, () => {
     const relationship = "[rel=\"stylesheet\"]";
     const cssStyleSheetSelector = kElementTypeLink + relationship + cssStyleSheetUrl;
-    const cssStyleSheetLink = document.head.querySelector(cssStyleSheetSelector);
+    const cssStyleSheetLinkElement = document.head.querySelector(cssStyleSheetSelector);
     const oswaldFontSelector = kElementTypeLink + relationship + oswaldFontUrl;
-    const oswaldFontLink = document.head.querySelector(oswaldFontSelector);
-    expect(isUnpopulated(cssStyleSheetLink)).toBe(false);
-    expect(isUnpopulated(oswaldFontLink)).toBe(false);
+    const oswaldFontLinkElement = document.head.querySelector(oswaldFontSelector);
+    expect(isUnpopulated(cssStyleSheetLinkElement)).toBe(false);
+    expect(isUnpopulated(oswaldFontLinkElement)).toBe(false);
 }); /* the HTML head contains the stylesheets necessary to render the user interface */
 
 function populateHTMLHead()

--- a/high_points/tests/html.test.js
+++ b/high_points/tests/html.test.js
@@ -19,10 +19,11 @@ beforeAll(() => {
 }); // beforeAll()
 
 test(`the HTML head contains the page title`, () => {
-    const elementTypeTitle = "title";
-    const titleElement = document.head.querySelector(elementTypeTitle);
+    const titleElementSelector = "title";
+    const titleElement = document.head.querySelector(titleElementSelector);
+    const pageTitle = titleElement.textContent;
     const expectedPageTitle = "United States High Points";
-    expect(titleElement.textContent).toBe(expectedPageTitle);
+    expect(pageTitle).toBe(expectedPageTitle);
 }); /* the HTML head contains the page title */
 
 test(`the HTML head contains preconnect links for the year string font`, () => {

--- a/high_points/tests/html.test.js
+++ b/high_points/tests/html.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+// Function includes:
+const mapFunctions = require('./environment/mapFunctions');
+const isUnpopulated = mapFunctions.isUnpopulated;
+
+// Miscellaneous constants:
+const kElementTypeLink = "link";
+
+// HTML Element URLs:
+const cssStyleSheetUrl = "[href=\"high_points/high_points_style.css\"]";
+const googleAPIsUrl = "[href=\"https://fonts.googleapis.com\"]";
+const gStaticUrl = "[href=\"https://fonts.gstatic.com\"]";
+const oswaldFontUrl = "[href=\"https://fonts.googleapis.com/css2?family=Oswald&display=swap\"]";
+
+beforeAll(() => {
+    const htmlFileRelativePath = "../../high_points.html";
+    const htmlFileAbsolutePath = path.join(__dirname, htmlFileRelativePath);
+    const utf8EncodingOption = "utf8";
+    document.documentElement.innerHTML = fs.readFileSync(htmlFileAbsolutePath, utf8EncodingOption);
+}); // beforeAll()
+
+test(`the HTML head contains the page title`, () => {
+    const elementTypeTitle = "title";
+    const title = document.head.querySelector(elementTypeTitle);
+    const expectedPageTitle = "United States High Points";
+    expect(title.textContent).toBe(expectedPageTitle);
+}); /* the HTML head contains the page title */
+
+test(`the HTML head contains preconnect links for the year string font`, () => {
+    const relationship = "[rel=\"preconnect\"]";
+    const googleAPIsSelector = kElementTypeLink + relationship + googleAPIsUrl;
+    const googleAPIsLink = document.head.querySelector(googleAPIsSelector);
+    const crossOriginAttribute = "[crossorigin]";
+    const gStaticSelector = kElementTypeLink + relationship + gStaticUrl + crossOriginAttribute;
+    const gStaticLink = document.head.querySelector(gStaticSelector);
+    expect(isUnpopulated(googleAPIsLink)).toBe(false);
+    expect(isUnpopulated(gStaticLink)).toBe(false);
+}); /* the HTML head contains preconnect links for the year string font */
+
+test(`the HTML head contains the stylesheets necessary to render the user interface`, () => {
+    const relationship = "[rel=\"stylesheet\"]";
+    const cssStyleSheetSelector = kElementTypeLink + relationship + cssStyleSheetUrl;
+    const cssStyleSheetLink = document.head.querySelector(cssStyleSheetSelector);
+    const oswaldFontSelector = kElementTypeLink + relationship + oswaldFontUrl;
+    const oswaldFontLink = document.head.querySelector(oswaldFontSelector);
+    expect(isUnpopulated(cssStyleSheetLink)).toBe(false);
+    expect(isUnpopulated(oswaldFontLink)).toBe(false);
+}); /* the HTML head contains the stylesheets necessary to render the user interface */

--- a/high_points/tests/html.test.js
+++ b/high_points/tests/html.test.js
@@ -15,10 +15,7 @@ const gStaticUrl = "[href=\"https://fonts.gstatic.com\"]";
 const oswaldFontUrl = "[href=\"https://fonts.googleapis.com/css2?family=Oswald&display=swap\"]";
 
 beforeAll(() => {
-    const htmlFileRelativePath = "../../high_points.html";
-    const htmlFileAbsolutePath = path.join(__dirname, htmlFileRelativePath);
-    const utf8EncodingOption = "utf8";
-    document.documentElement.innerHTML = fs.readFileSync(htmlFileAbsolutePath, utf8EncodingOption);
+    populateHTMLHead();
 }); // beforeAll()
 
 test(`the HTML head contains the page title`, () => {
@@ -48,3 +45,11 @@ test(`the HTML head contains the stylesheets necessary to render the user interf
     expect(isUnpopulated(cssStyleSheetLink)).toBe(false);
     expect(isUnpopulated(oswaldFontLink)).toBe(false);
 }); /* the HTML head contains the stylesheets necessary to render the user interface */
+
+function populateHTMLHead()
+{
+    const htmlFileRelativePath = "../../high_points.html";
+    const htmlFileAbsolutePath = path.join(__dirname, htmlFileRelativePath);
+    const utf8EncodingOption = "utf8";
+    document.documentElement.innerHTML = fs.readFileSync(htmlFileAbsolutePath, utf8EncodingOption);
+}

--- a/high_points/tests/html.test.js
+++ b/high_points/tests/html.test.js
@@ -18,14 +18,6 @@ beforeAll(() => {
     populateHTMLHead();
 }); // beforeAll()
 
-test(`the HTML head contains the page title`, () => {
-    const titleElementSelector = "title";
-    const titleElement = document.head.querySelector(titleElementSelector);
-    const pageTitle = titleElement.textContent;
-    const expectedPageTitle = "United States High Points";
-    expect(pageTitle).toBe(expectedPageTitle);
-}); /* the HTML head contains the page title */
-
 test(`the HTML head contains preconnect links for the year string font`, () => {
     const relationship = "[rel=\"preconnect\"]";
     const googleAPIsSelector = kElementTypeLink + relationship + googleAPIsUrl;
@@ -36,6 +28,14 @@ test(`the HTML head contains preconnect links for the year string font`, () => {
     expect(isUnpopulated(googleAPIsLinkElement)).toBe(false);
     expect(isUnpopulated(gStaticLinkElement)).toBe(false);
 }); /* the HTML head contains preconnect links for the year string font */
+
+test(`the HTML head contains the page title`, () => {
+    const titleElementSelector = "title";
+    const titleElement = document.head.querySelector(titleElementSelector);
+    const pageTitle = titleElement.textContent;
+    const expectedPageTitle = "United States High Points";
+    expect(pageTitle).toBe(expectedPageTitle);
+}); /* the HTML head contains the page title */
 
 test(`the HTML head contains the stylesheets necessary to render the user interface`, () => {
     const relationship = "[rel=\"stylesheet\"]";

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                 <p style="color: white;
                           font-family: verdana;
                           font-size: 12;">
-                    rev. 5 October 2025
+                    rev. 18 October 2025
                 </p>
             </div>
         </div>


### PR DESCRIPTION
This change fixes #39 . I thought I was unable to reproduce the issue in my Chrome debugger, until I realized that the fonts looked different between my phone and my computer. This led me to realize that the font family I'm using for the year strings, Impact, is only shipped with Windows and is not installed on most mobile devices.

This change adds a link to the Oswald font family (which is publicly available and hosted online), and updates the css to use Oswald for the year strings. The font should display uniformly across platforms now, and it should appear in such a way that adequate space between each year string distinguishes the strings from one another:

<img width="413" height="915" alt="image" src="https://github.com/user-attachments/assets/95669edf-6465-41af-bb77-db16175a2026" />
